### PR TITLE
Add `excluded_params` to extract_args_from_signature

### DIFF
--- a/knack/commands.py
+++ b/knack/commands.py
@@ -96,19 +96,23 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
 
 class CLICommandsLoader(object):
 
-    def __init__(self, cli_ctx=None, command_cls=CLICommand):
+    def __init__(self, cli_ctx=None, command_cls=CLICommand, excluded_command_handler_args=None):
         """ The loader of commands. It contains the command table and argument registries.
 
         :param cli_ctx: CLI Context
         :type cli_ctx: knack.cli.CLI
         :param command_cls: The command type that the command table will be populated with
         :type command_cls: knack.commands.CLICommand
+        :param excluded_command_handler_args: List of params to ignore and not extract from a commands handler.
+                                              By default we ignore ['self', 'kwargs'].
+        :type excluded_command_handler_args: list of str
         """
         from .cli import CLI
         if cli_ctx is not None and not isinstance(cli_ctx, CLI):
             raise CtxTypeError(cli_ctx)
         self.cli_ctx = cli_ctx
         self.command_cls = command_cls
+        self.excluded_command_handler_args = excluded_command_handler_args
         # A command table is a dictionary of name -> CLICommand instances
         self.command_table = dict()
         # An argument registry stores all arguments for commands
@@ -171,7 +175,8 @@ class CLICommandsLoader(object):
             return result
 
         def arguments_loader():
-            return extract_args_from_signature(CLICommandsLoader.get_op_handler(operation))
+            return extract_args_from_signature(CLICommandsLoader.get_op_handler(operation),
+                                               excluded_params=self.excluded_command_handler_args)
 
         def description_loader():
             return extract_full_summary_from_signature(CLICommandsLoader.get_op_handler(operation))

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -1,0 +1,80 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import os
+import stat
+import unittest
+import tempfile
+import mock
+from six.moves import configparser
+
+from knack.introspection import extract_full_summary_from_signature, option_descriptions, extract_args_from_signature
+
+
+def op1(self, arg1, arg2=False, arg3='mydefaultvalue', **kwargs):  # pylint: disable=unused-argument
+    """ This is the command description.
+    :param arg3: This is an arg for a test.
+    """
+    pass
+
+
+def op2(self, **kwargs):  # pylint: disable=unused-argument
+    # This operation has no summary
+    pass
+
+
+class TestExtractArgs(unittest.TestCase):
+
+    def test_extract_args_simple(self):
+        arguments = dict(extract_args_from_signature(op1))
+
+        self.assertEqual(len(arguments), 3)
+        self.assertNotIn('self', arguments)
+        self.assertNotIn('kwargs', arguments)
+
+        self.assertIn('arg1', arguments)
+        self.assertListEqual(arguments['arg1'].options_list, ['--arg1'])
+        self.assertTrue(arguments['arg1'].options['required'])
+
+        self.assertIn('arg2', arguments)
+        self.assertListEqual(arguments['arg2'].options_list, ['--arg2'])
+        self.assertFalse(arguments['arg2'].options['required'])
+        self.assertEqual(arguments['arg2'].options['action'], 'store_true')
+
+        self.assertIn('arg3', arguments)
+        self.assertListEqual(arguments['arg3'].options_list, ['--arg3'])
+        self.assertFalse(arguments['arg3'].options['required'])
+        self.assertEqual(arguments['arg3'].options['default'], 'mydefaultvalue')
+        self.assertEqual(arguments['arg3'].options['help'], 'This is an arg for a test.')
+
+    def test_extract_args_custom_exclude(self):
+        excluded_params = ['self', 'kwargs', 'arg2', 'arg3']
+        arguments = dict(extract_args_from_signature(op1, excluded_params=excluded_params))
+        self.assertEqual(len(arguments), 1)
+        for param in excluded_params:
+            self.assertNotIn(param, arguments)
+
+
+class TestOptionDescriptions(unittest.TestCase):
+
+    def test_option_desc_simple(self):
+        option_descs = option_descriptions(op1)
+        self.assertIn('arg3', option_descs)
+        self.assertEqual(option_descs['arg3'], 'This is an arg for a test.')
+
+
+class TestExtractSummary(unittest.TestCase):
+
+    def test_extract_summary(self):
+        summary = extract_full_summary_from_signature(op1)
+        self.assertEqual(summary, 'This is the command description.')
+
+    def test_extract_summary_no_summary(self):
+        summary = extract_full_summary_from_signature(op2)
+        self.assertEqual(summary, '')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes https://github.com/Microsoft/knack/issues/29

Now, you have to specify the excluded params yourself. Before, what we excluded was very Azure CLI specific and not general enough.