### PR TITLE
[minor breaking change] Consolidate exception handling so tests can capture the right exception

### DIFF
--- a/knack/cli.py
+++ b/knack/cli.py
@@ -157,8 +157,11 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
             func(self, **kwargs)
 
     def exception_handler(self, ex):  # pylint: disable=no-self-use
-        """ The default exception handler for unknown CLI exceptions. """
-        logger.exception(ex)
+        """ The default exception handler"""
+        if isinstance(ex, CLIError):
+            logger.error(ex)
+        else:
+            logger.exception(ex)
         return 1
 
     def invoke(self, args, initial_invocation_data=None, out_file=None):
@@ -198,9 +201,6 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
                     self.output.out(cmd_result, formatter=formatter, out_file=out_file)
             self.raise_event(EVENT_CLI_POST_EXECUTE)
             exit_code = 0
-        except CLIError as ex:
-            logger.error(ex)
-            exit_code = 1
         except KeyboardInterrupt:
             exit_code = 1
         except Exception as ex:  # pylint: disable=broad-except

--- a/knack/cli.py
+++ b/knack/cli.py
@@ -157,7 +157,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
             func(self, **kwargs)
 
     def exception_handler(self, ex):  # pylint: disable=no-self-use
-        """ The default exception handler"""
+        """ The default exception handler """
         if isinstance(ex, CLIError):
             logger.error(ex)
         else:


### PR DESCRIPTION
It is one of the options to address test breaks tracked by https://github.com/Azure/azure-cli/issues/5032
The other option is to have [test sdk](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-testsdk/azure/cli/testsdk/patches.py#L37) workaround by adding a new patch, but we still need an  extraction here say, to a method, so tests can mock.

//CC @troydai  @tjprescott  @derekbekoe   
  