### PR TITLE
expose a callback to let client side perform extra logics

### DIFF
--- a/knack/util.py
+++ b/knack/util.py
@@ -56,8 +56,8 @@ def to_snake_case(s):
 
 def todict(obj, post_processor=None):  # pylint: disable=too-many-return-statements
     """
-    Convert an object to a dictionary. Use 'post_processor' for custom logics.
-    Note, the post_processor will be invoked after every elelment gets converted
+    Convert an object to a dictionary. Use 'post_processor(original_obj, dictionary)' to update the
+    dictionary in the process
     """
     if isinstance(obj, dict):
         result = {k: todict(v, post_processor) for (k, v) in obj.items()}

--- a/knack/util.py
+++ b/knack/util.py
@@ -54,12 +54,14 @@ def to_snake_case(s):
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 
-def todict(obj):  # pylint: disable=too-many-return-statements
-
+def todict(obj, value_filter=None):  # pylint: disable=too-many-return-statements
+    """ 
+    Convert an object to a dictionary. Use 'value_filter' to ignore specified values
+    """
     if isinstance(obj, dict):
-        return {k: todict(v) for (k, v) in obj.items()}
+        return {k: todict(v, value_filter) for (k, v) in obj.items() if (not value_filter or value_filter(obj, k, v))}
     elif isinstance(obj, list):
-        return [todict(a) for a in obj]
+        return [todict(a, value_filter) for a in obj]
     elif isinstance(obj, Enum):
         return obj.value
     elif isinstance(obj, (date, time, datetime)):
@@ -67,9 +69,9 @@ def todict(obj):  # pylint: disable=too-many-return-statements
     elif isinstance(obj, timedelta):
         return str(obj)
     elif hasattr(obj, '_asdict'):
-        return todict(obj._asdict())
+        return todict(obj._asdict(), value_filter)
     elif hasattr(obj, '__dict__'):
-        return dict([(to_camel_case(k), todict(v))
+        return dict([(to_camel_case(k), todict(v, value_filter))
                      for k, v in obj.__dict__.items()
-                     if not callable(v) and not k.startswith('_')])
+                     if not callable(v) and not k.startswith('_') and (not value_filter or value_filter(obj, k, v))])
     return obj

--- a/knack/util.py
+++ b/knack/util.py
@@ -55,8 +55,9 @@ def to_snake_case(s):
 
 
 def todict(obj, value_filter=None):  # pylint: disable=too-many-return-statements
-    """ 
-    Convert an object to a dictionary. Use 'value_filter' to ignore specified values
+    """
+    Convert an object to a dictionary. Use 'value_filter' for custom logics,
+    e.g., to ignore specified properties
     """
     if isinstance(obj, dict):
         return {k: todict(v, value_filter) for (k, v) in obj.items() if (not value_filter or value_filter(obj, k, v))}

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = '0.3.2'
+VERSION = '0.3.3'
 
 DEPENDENCIES = [
     'argcomplete',


### PR DESCRIPTION
Say, to ignore the empty `additional_properties`, the [CLI code](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/commands/__init__.py#L321) will be updated to 
```python
  def prune_empty_additional_props(obj, property_name, value):
         from msrest.serialization import Model
         return not isinstance(obj, Model) or property_name != 'additional_properties' or value

  result = todict(result, prune_empty_additional_props)
```
The initial profile data shows only 4 more milliseconds to list 36 virtual machines with overall 2.45 seconds realtime, so the increase is very marginal.
