### PR TITLE
output: don't skip false value on auto-tabulating

### DIFF
--- a/knack/output.py
+++ b/knack/output.py
@@ -165,7 +165,7 @@ class _TableOutput(object):  # pylint: disable=too-few-public-methods
             for k in keys:
                 if k in _TableOutput.SKIP_KEYS:
                     continue
-                if item[k] and not isinstance(item[k], (list, dict, set)):
+                if item[k] is not None and not isinstance(item[k], (list, dict, set)):
                     new_entry[_TableOutput._capitalize_first_char(k)] = item[k]
         except AttributeError:
             # handles odd cases where a string/bool/etc. is returned

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -83,11 +83,12 @@ class TestOutput(unittest.TestCase):
         obj = OrderedDict()
         obj['active'] = True
         obj['val'] = '0b1f6472'
+        obj['lun'] = 0
         output_producer.out(CommandResultItem(obj), formatter=format_table, out_file=self.io)
         self.assertEqual(normalize_newlines(self.io.getvalue()), normalize_newlines(
-            """Active    Val
---------  --------
-True      0b1f6472
+            """Active      Lun  Val
+--------  -----  --------
+True          0  0b1f6472
 """))
 
     def test_out_table_list_of_lists(self):


### PR DESCRIPTION
//CC @derekbekoe 
For background, this was found by CLI users that VM's 1st data disk's lun is not displayed, because the lun is `0`
I believe we skip false values for some reasons, so if we would like maintain the old behavior as much as possible, i can change the code to only bring back the `0`. Up to you though. Also let me know if you have other ideas.