### PR TITLE
Add deprecation mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ $RECYCLE.BIN/
 .project
 .pydevproject
 .pytest_cache/
+env3/
+env2/

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ $RECYCLE.BIN/
 .vscode/cSpell.json
 .project
 .pydevproject
+.pytest_cache/

--- a/VS2015.sln
+++ b/VS2015.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.16
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "knack", "knack.pyproj", "{27802D2F-7F88-44E9-9818-C960569098A6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{27802D2F-7F88-44E9-9818-C960569098A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27802D2F-7F88-44E9-9818-C960569098A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {87C87E54-C86A-44F2-96F7-D282A01692A9}
+	EndGlobalSection
+EndGlobal

--- a/VS2017.sln
+++ b/VS2017.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.16
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "knack", "knack.pyproj", "{27802D2F-7F88-44E9-9818-C960569098A6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{27802D2F-7F88-44E9-9818-C960569098A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27802D2F-7F88-44E9-9818-C960569098A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {87C87E54-C86A-44F2-96F7-D282A01692A9}
+	EndGlobalSection
+EndGlobal

--- a/VS2017.sln
+++ b/VS2017.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "knack", "knack.pyproj", "{27802D2F-7F88-44E9-9818-C960569098A6}"
 EndProject

--- a/examples/exapp2
+++ b/examples/exapp2
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+""" User registers commands with CommandGroups """
+
+import os
+import sys
+from collections import OrderedDict
+
+from knack import CLI
+from knack.commands import CLICommandsLoader, CommandGroup
+from knack.arguments import ArgumentsContext
+from knack.help import CLIHelp
+
+from knack.help_files import helps
+
+cli_name = os.path.basename(__file__)
+
+helps['abc'] = """
+    type: group
+    short-summary: Manage the alphabet of words.
+"""
+
+helps['abc list'] = """
+    type: command
+    short-summary: List the alphabet.
+    examples:
+        - name: It's pretty straightforward.
+          text: {cli_name} abc list
+""".format(cli_name=cli_name)
+
+def a_test_command_handler():
+    return [{'a': 1, 'b': 1234}, {'a': 3, 'b': 4}]
+
+
+def abc_list_command_handler():
+    import string
+    return list(string.ascii_lowercase)
+
+def hello_command_handler(myarg=None, abc=None):
+    return ['hello', 'world', myarg, abc]
+
+WELCOME_MESSAGE = r"""
+   _____ _      _____ 
+  / ____| |    |_   _|
+ | |    | |      | |  
+ | |    | |      | |  
+ | |____| |____ _| |_ 
+  \_____|______|_____|
+                      
+                      
+Welcome to the cool new CLI!
+"""
+
+class MyCLIHelp(CLIHelp):
+
+    def __init__(self, cli_ctx=None):
+        super(MyCLIHelp, self).__init__(cli_ctx=cli_ctx,
+                                        privacy_statement='My privacy statement.',
+                                        welcome_message=WELCOME_MESSAGE)
+
+class MyCommandsLoader(CLICommandsLoader):
+
+    def load_command_table(self, args):
+        with CommandGroup(self, 'hello', '__main__#{}') as g:
+            g.command('world', 'hello_command_handler', confirmation=True)
+        with CommandGroup(self, 'abc', '__main__#{}') as g:
+                g.command('list', 'abc_list_command_handler')
+                g.command('show', 'a_test_command_handler')
+                g.command('get', 'a_test_command_handler', deprecate_info=g.deprecate(redirect='show', hide='0.1.0'))
+        return super(MyCommandsLoader, self).load_command_table(args)
+
+    def load_arguments(self, command):
+        with ArgumentsContext(self, 'hello world') as ac:
+            ac.argument('myarg', type=int, default=100)
+        super(MyCommandsLoader, self).load_arguments(command)
+
+
+class MyCLI(CLI):
+
+    def get_cli_version(self):
+        return '0.1.0'
+
+
+mycli = MyCLI(cli_name=cli_name,
+              config_dir=os.path.join('~', '.{}'.format(cli_name)),
+              config_env_var_prefix=cli_name,
+              commands_loader_cls=MyCommandsLoader,
+              help_cls=MyCLIHelp)
+exit_code = mycli.invoke(sys.argv[1:])
+sys.exit(exit_code)

--- a/knack.pyproj
+++ b/knack.pyproj
@@ -11,7 +11,8 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>MSBuild|{d507db9a-6cd5-43f5-b01e-b261519c3cf1}|$(MSBuildProjectFullPath)</InterpreterId>
+    <InterpreterId>{7393b5c6-e58e-4149-98f6-354e3a48ee70}</InterpreterId>
+    <InterpreterVersion>3.5</InterpreterVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
@@ -56,6 +57,9 @@
     <Compile Include="tests\test_command_registration.py" />
     <Compile Include="tests\test_completion.py" />
     <Compile Include="tests\test_config.py" />
+    <Compile Include="tests\test_deprecation.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="tests\test_help.py" />
     <Compile Include="tests\test_introspection.py" />
     <Compile Include="tests\test_log.py" />
@@ -93,15 +97,6 @@
       <LibraryPath>Lib\</LibraryPath>
       <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
       <Architecture>Amd64</Architecture>
-    </Interpreter>
-    <Interpreter Include="env\">
-      <Id>knack</Id>
-      <Description>env (Python 3.6 (32-bit))</Description>
-      <InterpreterPath>Scripts\python.exe</InterpreterPath>
-      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
-      <Version>3.6</Version>
-      <Architecture>X86</Architecture>
-      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
     </Interpreter>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />

--- a/knack.pyproj
+++ b/knack.pyproj
@@ -11,8 +11,7 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>{7393b5c6-e58e-4149-98f6-354e3a48ee70}</InterpreterId>
-    <InterpreterVersion>3.5</InterpreterVersion>
+    <InterpreterId>MSBuild|env2|$(MSBuildProjectFullPath)</InterpreterId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
@@ -79,7 +78,16 @@
   </ItemGroup>
   <ItemGroup>
     <Interpreter Include="env2\">
-      <Id>{d507db9a-6cd5-43f5-b01e-b261519c3cf1}</Id>
+      <Id>env2</Id>
+      <Version>2.7</Version>
+      <Description>env2 (Python 2.7 (32-bit))</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+      <Architecture>X86</Architecture>
+    </Interpreter>
+    <Interpreter Include="env2\">
+      <Id>{52196499-2eb9-4ba7-924a-ca67b294886b}</Id>
       <Version>2.7</Version>
       <Description>env2 (Python 2.7)</Description>
       <InterpreterPath>Scripts\python.exe</InterpreterPath>
@@ -89,14 +97,13 @@
       <Architecture>X86</Architecture>
     </Interpreter>
     <Interpreter Include="env3\">
-      <Id>{7393b5c6-e58e-4149-98f6-354e3a48ee70}</Id>
-      <Version>3.5</Version>
-      <Description>env3 (Python 3.6)</Description>
+      <Id>env3</Id>
+      <Version>3.6</Version>
+      <Description>env3 (Python 3.6 (64-bit))</Description>
       <InterpreterPath>Scripts\python.exe</InterpreterPath>
       <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
-      <LibraryPath>Lib\</LibraryPath>
       <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
-      <Architecture>Amd64</Architecture>
+      <Architecture>X64</Architecture>
     </Interpreter>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />

--- a/knack.pyproj
+++ b/knack.pyproj
@@ -1,0 +1,107 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{27802d2f-7f88-44e9-9818-c960569098a6}</ProjectGuid>
+    <ProjectHome />
+    <StartupFile>knack\__init__.py</StartupFile>
+    <SearchPath />
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
+    <LaunchProvider>Standard Python launcher</LaunchProvider>
+    <InterpreterId>MSBuild|knack|$(MSBuildProjectFullPath)</InterpreterId>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
+  <PropertyGroup>
+    <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">10.0</VisualStudioVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="requirements.txt" />
+    <Content Include="tox.ini" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="knack\arguments.py" />
+    <Compile Include="knack\cli.py" />
+    <Compile Include="knack\commands.py" />
+    <Compile Include="knack\completion.py" />
+    <Compile Include="knack\config.py" />
+    <Compile Include="knack\deprecation.py" />
+    <Compile Include="knack\events.py" />
+    <Compile Include="knack\help.py" />
+    <Compile Include="knack\help_files.py" />
+    <Compile Include="knack\introspection.py" />
+    <Compile Include="knack\invocation.py" />
+    <Compile Include="knack\log.py" />
+    <Compile Include="knack\output.py" />
+    <Compile Include="knack\parser.py" />
+    <Compile Include="knack\prompting.py" />
+    <Compile Include="knack\query.py" />
+    <Compile Include="knack\testsdk\base.py" />
+    <Compile Include="knack\testsdk\checkers.py" />
+    <Compile Include="knack\testsdk\const.py" />
+    <Compile Include="knack\testsdk\decorators.py" />
+    <Compile Include="knack\testsdk\exceptions.py" />
+    <Compile Include="knack\testsdk\patches.py" />
+    <Compile Include="knack\testsdk\recording_processors.py" />
+    <Compile Include="knack\testsdk\util.py" />
+    <Compile Include="knack\testsdk\__init__.py" />
+    <Compile Include="knack\util.py" />
+    <Compile Include="knack\__init__.py" />
+    <Compile Include="scripts\license_verify.py" />
+    <Compile Include="setup.py" />
+    <Compile Include="tests\test_cli_scenarios.py" />
+    <Compile Include="tests\test_command_registration.py" />
+    <Compile Include="tests\test_completion.py" />
+    <Compile Include="tests\test_config.py" />
+    <Compile Include="tests\test_help.py" />
+    <Compile Include="tests\test_introspection.py" />
+    <Compile Include="tests\test_log.py" />
+    <Compile Include="tests\test_output.py" />
+    <Compile Include="tests\test_parser.py" />
+    <Compile Include="tests\test_prompting.py" />
+    <Compile Include="tests\test_query.py" />
+    <Compile Include="tests\test_util.py" />
+    <Compile Include="tests\util.py" />
+    <Compile Include="tests\__init__.py" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="knack" />
+    <Folder Include="knack\testsdk" />
+    <Folder Include="scripts" />
+    <Folder Include="tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <Interpreter Include=".tox\">
+      <Id>knack</Id>
+      <Description>.tox (Python 2.7 (32-bit))</Description>
+      <InterpreterPath>py27\Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>py27\Scripts\pythonw.exe</WindowsInterpreterPath>
+      <Version>2.7</Version>
+      <Architecture>X86</Architecture>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+    </Interpreter>
+    <Interpreter Include="env1\">
+      <Id>{1ab286a6-9154-438b-b43d-7ab08d2d91c1}</Id>
+      <Version>3.5</Version>
+      <Description>env1 (Python 3.6)</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <LibraryPath>Lib\</LibraryPath>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+      <Architecture>Amd64</Architecture>
+    </Interpreter>
+    <Interpreter Include="env\">
+      <Id>knack</Id>
+      <Description>env (Python 3.6 (32-bit))</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <Version>3.6</Version>
+      <Architecture>X86</Architecture>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+    </Interpreter>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
+</Project>

--- a/knack.pyproj
+++ b/knack.pyproj
@@ -11,7 +11,7 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>MSBuild|knack|$(MSBuildProjectFullPath)</InterpreterId>
+    <InterpreterId>MSBuild|{d507db9a-6cd5-43f5-b01e-b261519c3cf1}|$(MSBuildProjectFullPath)</InterpreterId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
@@ -74,19 +74,20 @@
     <Folder Include="tests" />
   </ItemGroup>
   <ItemGroup>
-    <Interpreter Include=".tox\">
-      <Id>knack</Id>
-      <Description>.tox (Python 2.7 (32-bit))</Description>
-      <InterpreterPath>py27\Scripts\python.exe</InterpreterPath>
-      <WindowsInterpreterPath>py27\Scripts\pythonw.exe</WindowsInterpreterPath>
+    <Interpreter Include="env2\">
+      <Id>{d507db9a-6cd5-43f5-b01e-b261519c3cf1}</Id>
       <Version>2.7</Version>
-      <Architecture>X86</Architecture>
+      <Description>env2 (Python 2.7)</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <LibraryPath>Lib\</LibraryPath>
       <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+      <Architecture>X86</Architecture>
     </Interpreter>
-    <Interpreter Include="env1\">
-      <Id>{1ab286a6-9154-438b-b43d-7ab08d2d91c1}</Id>
+    <Interpreter Include="env3\">
+      <Id>{7393b5c6-e58e-4149-98f6-354e3a48ee70}</Id>
       <Version>3.5</Version>
-      <Description>env1 (Python 3.6)</Description>
+      <Description>env3 (Python 3.6)</Description>
       <InterpreterPath>Scripts\python.exe</InterpreterPath>
       <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
       <LibraryPath>Lib\</LibraryPath>

--- a/knack.pyproj
+++ b/knack.pyproj
@@ -19,6 +19,9 @@
     <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">10.0</VisualStudioVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="examples\exapp" />
+    <Content Include="examples\exapp2" />
+    <Content Include="examples\test_exapp" />
     <Content Include="requirements.txt" />
     <Content Include="tox.ini" />
   </ItemGroup>
@@ -71,6 +74,7 @@
     <Compile Include="tests\__init__.py" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="examples\" />
     <Folder Include="knack" />
     <Folder Include="knack\testsdk" />
     <Folder Include="scripts" />

--- a/knack/__init__.py
+++ b/knack/__init__.py
@@ -3,9 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from .cli import CLI
-from .commands import CLICommandsLoader, CLICommand
-from .arguments import ArgumentsContext
-from .help import CLIHelp
+import sys
+
+from knack.cli import CLI
+from knack.commands import CLICommandsLoader, CLICommand
+from knack.arguments import ArgumentsContext
+from knack.help import CLIHelp
 
 __all__ = ['CLI', 'CLICommandsLoader', 'CLICommand', 'CLIHelp', 'ArgumentsContext']

--- a/knack/arguments.py
+++ b/knack/arguments.py
@@ -210,16 +210,15 @@ class ArgumentsContext(object):
     def deprecate(self, **kwargs):
 
         def _get_deprecated_arg_message(self):
-            line1 = "{} '{}' has been deprecated and will be removed ".format(
+            msg = "{} '{}' has been deprecated and will be removed ".format(
                 self.object_type, self.target).capitalize()
             if self.expiration:
-                line1 += "in version '{}'.".format(self.expiration)
+                msg += "in version '{}'.".format(self.expiration)
             else:
-                line1 += 'in a future release.'
-            lines = [line1]
+                msg += 'in a future release.'
             if self.redirect:
-                lines.append("Use '{}' instead.".format(self.redirect))
-            return ' '.join(lines)
+                msg += " Use '{}' instead.".format(self.redirect)
+            return msg
 
         target = kwargs.get('target', '')
         kwargs['object_type'] = 'option' if target.startswith('-') else 'argument'

--- a/knack/arguments.py
+++ b/knack/arguments.py
@@ -196,13 +196,16 @@ class ArgumentsContext(object):
 
             return DeprecatedOptionAction
 
+        action = kwargs.get('action', None)
+
         deprecate_info = kwargs.get('deprecate_info', None)
         if deprecate_info:
             deprecate_info.target = deprecate_info.target or argument_dest
-            kwargs['action'] = _handle_argument_deprecation(deprecate_info)
+            action = _handle_argument_deprecation(deprecate_info)
         deprecated_opts = [x for x in kwargs.get('options_list', []) if isinstance(x, Deprecated)]
         if deprecated_opts:
-            kwargs['action'] = _handle_option_deprecation(deprecated_opts)
+            action = _handle_option_deprecation(deprecated_opts)
+        return action
 
     def deprecate(self, **kwargs):
 
@@ -233,7 +236,7 @@ class ArgumentsContext(object):
         :param kwargs: Possible values: `options_list`, `validator`, `completer`, `nargs`, `action`, `const`, `default`,
                        `type`, `choices`, `required`, `help`, `metavar`. See /docs/arguments.md.
         """
-        self._handle_deprecations(argument_dest, **kwargs)
+        kwargs['action'] = self._handle_deprecations(argument_dest, **kwargs)
         self.command_loader.argument_registry.register_cli_argument(self.command_scope,
                                                                     argument_dest,
                                                                     arg_type,
@@ -257,7 +260,7 @@ class ArgumentsContext(object):
         :param kwargs: Possible values: `options_list`, `validator`, `completer`, `nargs`, `action`, `const`, `default`,
                        `type`, `choices`, `required`, `help`, `metavar`. See /docs/arguments.md.
         """
-        self._handle_deprecations(argument_dest, **kwargs)
+        kwargs['action'] = self._handle_deprecations(argument_dest, **kwargs)
         self.command_loader.extra_argument_registry[self.command_scope][argument_dest] = CLICommandArgument(
             argument_dest, **kwargs)
 

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -265,8 +265,10 @@ class CommandGroup(object):
                        Possible values: `client_factory`, `arguments_loader`, `description_loader`, `description`,
                        `formatter_class`, `table_transformer`, `deprecate_info`, `validator`, `confirmation`.
         """
+        import copy
+
         command_name = '{} {}'.format(self.group_name, name) if self.group_name else name
-        command_kwargs = self.group_kwargs.copy()
+        command_kwargs = copy.deepcopy(self.group_kwargs)
         command_kwargs.update(kwargs)
         # don't inherit deprecation info from command group
         command_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -4,12 +4,12 @@
 # --------------------------------------------------------------------------------------------
 
 import types
-import copy
 from collections import OrderedDict, defaultdict
 from importlib import import_module
 
 import six
 
+from .deprecation import Deprecated
 from .prompting import prompt_y_n, NoTTYException
 from .util import CLIError, CtxTypeError
 from .arguments import ArgumentRegistry, CLICommandArgument
@@ -93,12 +93,8 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         return self(**kwargs)
 
     def __call__(self, *args, **kwargs):
+
         cmd_args = args[0]
-        if self.deprecate_info is not None:
-            text = 'This command is deprecating and will be removed in future releases.'
-            if self.deprecate_info:
-                text += " Use '{}' instead.".format(self.deprecate_info)
-            logger.warning(text)
 
         confirm = self.confirmation and not cmd_args.pop('yes', None) \
             and not self.cli_ctx.config.getboolean('core', 'disable_confirm_prompt', fallback=False)
@@ -142,6 +138,8 @@ class CLICommandsLoader(object):
         self.excluded_command_handler_args = excluded_command_handler_args
         # A command table is a dictionary of name -> CLICommand instances
         self.command_table = dict()
+        # A command group table is a dictionary of names -> CommandGroup instances
+        self.command_group_table = dict()
         # An argument registry stores all arguments for commands
         self.argument_registry = ArgumentRegistry()
         self.extra_argument_registry = defaultdict(lambda: {})
@@ -221,8 +219,13 @@ class CLICommandsLoader(object):
         except (ValueError, AttributeError):
             raise ValueError("The operation '{}' is invalid.".format(operation))
 
+    def deprecate(self, **kwargs):
+        kwargs['object_type'] = 'command group'
+        return Deprecated(self.cli_ctx, **kwargs)
+
 
 class CommandGroup(object):
+
     def __init__(self, command_loader, group_name, operations_tmpl, **kwargs):
         """ Context manager for registering commands that share common properties.
 
@@ -240,6 +243,10 @@ class CommandGroup(object):
         self.group_name = group_name
         self.operations_tmpl = operations_tmpl
         self.group_kwargs = kwargs
+        Deprecated.ensure_new_style_deprecation(self.command_loader.cli_ctx, self.group_kwargs, 'command group')
+        if kwargs['deprecate_info']:
+            kwargs['deprecate_info'].target = group_name
+        self.command_loader.command_group_table[group_name] = self
 
     def __enter__(self):
         return self
@@ -259,9 +266,16 @@ class CommandGroup(object):
                        `formatter_class`, `table_transformer`, `deprecate_info`, `validator`, `confirmation`.
         """
         command_name = '{} {}'.format(self.group_name, name) if self.group_name else name
-        command_kwargs = copy.deepcopy(self.group_kwargs)
+        command_kwargs = self.group_kwargs.copy()
         command_kwargs.update(kwargs)
+        # don't inherit deprecation info from command group
+        command_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
+
         self.command_loader.command_table[command_name] = self.command_loader.create_command(
             command_name,
             self.operations_tmpl.format(handler_name),
             **command_kwargs)
+
+    def deprecate(self, **kwargs):
+        kwargs['object_type'] = 'command'
+        return Deprecated(self.command_loader.cli_ctx, **kwargs)

--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -126,10 +126,9 @@ class Deprecated(object):
     # pylint: disable=no-self-use
     def _version_less_than_or_equal_to(self, v1, v2):
         """ Returns true if v1 <= v2. """
-        from pkg_resources import parse_version
-        v1_ver = parse_version(v1)
-        v2_ver = parse_version(v2)
-        return v1_ver <= v2_ver
+        # pylint: disable=no-name-in-module, import-error
+        from distutils.version import LooseVersion
+        return LooseVersion(v1) <= LooseVersion(v2)
 
     def expired(self):
         if self.expiration:

--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -5,10 +5,6 @@
 
 from six import string_types as STRING_TYPES
 
-from knack.log import get_logger
-
-logger = get_logger(__name__)
-
 
 DEFAULT_DEPRECATED_TAG = '[Deprecated]'
 
@@ -99,15 +95,14 @@ class Deprecated(object):
         self.expiration = expiration
 
         def _default_get_message(self):
-            line1 = "This {} has been deprecated and will be removed ".format(self.object_type)
+            msg = "This {} has been deprecated and will be removed ".format(self.object_type)
             if self.expiration:
-                line1 += "in version '{}'.".format(self.expiration)
+                msg += "in version '{}'.".format(self.expiration)
             else:
-                line1 += 'in a future release.'
-            lines = [line1]
+                msg += 'in a future release.'
             if self.redirect:
-                lines.append("Use '{}' instead.".format(self.redirect))
-            return ' '.join(lines)
+                msg += " Use '{}' instead.".format(self.redirect)
+            return msg
 
         self._get_tag = tag_func or (lambda _: DEFAULT_DEPRECATED_TAG)
         self._get_message = message_func or _default_get_message
@@ -170,16 +165,15 @@ class ImplicitDeprecated(Deprecated):
     def __init__(self, **kwargs):
 
         def get_implicit_deprecation_message(self):
-            line1 = "This {} is implicitly deprecated because command group '{}' is deprecated " \
-                    "and will be removed ".format(self.object_type, self.target)
+            msg = "This {} is implicitly deprecated because command group '{}' is deprecated " \
+                  "and will be removed ".format(self.object_type, self.target)
             if self.expiration:
-                line1 += "in version '{}'.".format(self.expiration)
+                msg += "in version '{}'.".format(self.expiration)
             else:
-                line1 += 'in a future release.'
-            lines = [line1]
+                msg += 'in a future release.'
             if self.redirect:
-                lines.append("Use '{}' instead.".format(self.redirect))
-            return ' '.join(lines)
+                msg += " Use '{}' instead.".format(self.redirect)
+            return msg
 
         kwargs.update({
             'tag_func': lambda _: '',

--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import colorama
+from six import string_types as STRING_TYPES
 
 from knack.log import get_logger
 
@@ -58,7 +59,7 @@ class Deprecated(object):
         deprecate_info = kwargs.get('deprecate_info', None)
         if isinstance(deprecate_info, Deprecated):
             deprecate_info.object_type = object_type
-        elif isinstance(deprecate_info, str):
+        elif isinstance(deprecate_info, STRING_TYPES):
             deprecate_info = Deprecated(cli_ctx, redirect=deprecate_info, object_type=object_type)
         kwargs['deprecate_info'] = deprecate_info
         return deprecate_info
@@ -107,11 +108,7 @@ class Deprecated(object):
                 lines.append("Use '{}' instead.".format(self.redirect))
             return ' '.join(lines)
 
-        # pylint: disable=unused-argument
-        def _default_get_tag(self):
-            return DEFAULT_DEPRECATED_TAG
-
-        self._get_tag = tag_func or _default_get_tag
+        self._get_tag = tag_func or (lambda _: DEFAULT_DEPRECATED_TAG)
         self._get_message = message_func or _default_get_message
 
     # pylint: disable=no-self-use
@@ -141,7 +138,7 @@ class Deprecated(object):
         hidden = False
         if isinstance(self.hide, bool):
             hidden = self.hide
-        elif isinstance(self.hide, str):
+        elif isinstance(self.hide, STRING_TYPES):
             cli_version = self.cli_ctx.get_cli_version()
             hidden = self._version_less_than_or_equal_to(self.hide, cli_version)
         return hidden

--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -97,13 +97,15 @@ class Deprecated(object):
         self.expiration = expiration
 
         def _default_get_message(self):
-            message = "This {} has been deprecated and will be removed ".format(self.object_type)
+            line1 = "This {} has been deprecated and will be removed ".format(self.object_type)
             if self.expiration:
-                message += "in version '{}'. ".format(self.expiration)
+                line1 += "in version '{}'.".format(self.expiration)
             else:
-                message += 'in a future release. '
-            message += "Use '{}' instead. ".format(self.redirect) if self.redirect else ''
-            return message.lstrip()
+                line1 += 'in a future release.'
+            lines = [line1]
+            if self.redirect:
+                lines.append("Use '{}' instead.".format(self.redirect))
+            return ' '.join(lines)
 
         # pylint: disable=unused-argument
         def _default_get_tag(self):
@@ -163,14 +165,16 @@ class ImplicitDeprecated(Deprecated):
     def __init__(self, **kwargs):
 
         def get_implicit_deprecation_message(self):
-            message = "This {} is implicitly deprecated because command group '{}' is deprecated " \
-                "and will be removed ".format(self.object_type, self.target)
+            line1 = "This {} is implicitly deprecated because command group '{}' is deprecated " \
+                    "and will be removed ".format(self.object_type, self.target)
             if self.expiration:
-                message += "in version '{}'. ".format(self.expiration)
+                line1 += "in version '{}'.".format(self.expiration)
             else:
-                message += 'in a future release. '
-            message += "Use '{}' instead. ".format(self.redirect) if self.redirect else ''
-            return message.lstrip()
+                line1 += 'in a future release.'
+            lines = [line1]
+            if self.redirect:
+                lines.append("Use '{}' instead.".format(self.redirect))
+            return ' '.join(lines)
 
         kwargs.update({
             'tag_func': lambda _: '',

--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -1,0 +1,179 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import colorama
+
+from knack.log import get_logger
+
+logger = get_logger(__name__)
+
+
+DEFAULT_DEPRECATED_TAG = '[Deprecated]'
+
+
+def resolve_deprecate_info(cli_ctx, name):
+
+    def _get_command(name):
+        return cli_ctx.invocation.commands_loader.command_table[name]
+
+    def _get_command_group(name):
+        return cli_ctx.invocation.commands_loader.command_group_table.get(name, None)
+
+    deprecate_info = None
+    try:
+        command = _get_command(name)
+        deprecate_info = getattr(command, 'deprecate_info', None)
+    except KeyError:
+        command_group = _get_command_group(name)
+        group_kwargs = getattr(command_group, 'group_kwargs', None)
+        if group_kwargs:
+            deprecate_info = group_kwargs.get('deprecate_info', None)
+    return deprecate_info
+
+
+class ColorizedString(object):
+
+    def __init__(self, message, color):
+        self._message = message
+        self._color = getattr(colorama.Fore, color.upper(), None)
+
+    def __len__(self):
+        return len(self._message)
+
+    def __str__(self):
+        if not self._color:
+            return self._message
+        return self._color + self._message + colorama.Fore.RESET
+
+
+# pylint: disable=too-many-instance-attributes
+class Deprecated(object):
+
+    @staticmethod
+    def ensure_new_style_deprecation(cli_ctx, kwargs, object_type):
+        """ Helper method to make the previous string-based deprecate_info kwarg
+            work with the new style. """
+        deprecate_info = kwargs.get('deprecate_info', None)
+        if isinstance(deprecate_info, Deprecated):
+            deprecate_info.object_type = object_type
+        elif isinstance(deprecate_info, str):
+            deprecate_info = Deprecated(cli_ctx, redirect=deprecate_info, object_type=object_type)
+        kwargs['deprecate_info'] = deprecate_info
+        return deprecate_info
+
+    def __init__(self, cli_ctx=None, object_type='', target=None, redirect=None, hide=False, expiration=None,
+                 tag_func=None, message_func=None):
+        """ Create a collection of deprecation metadata.
+
+        :param cli_ctx: The CLI context associated with the deprecated item.
+        :type cli_ctx: knack.cli.CLI
+        :param object_type: A label describing the type of object being deprecated.
+        :type: object_type: str
+        :param target: The name of the object being deprecated.
+        :type target: str
+        :param redirect: The alternative to redirect users to in lieu of the deprecated item. If omitted it, there is
+                         no alternative.
+        :type redirect: str
+        :param hide: A boolean or CLI version at or above-which the deprecated item will no longer appear
+                     in help text, but will continue to work. Warnings will be displayed if the deprecated
+                     item is used.
+        :type hide: bool OR str
+        :param expiration: The CLI version at or above-which the deprecated item will no longer work.
+        :type expiration: str
+        :param tag_func: Callable which returns the desired unformatted tag string for the deprecated item.
+                         Omit to use the default.
+        :type tag_func: callable
+        :param message_func: Callable which returns the desired unformatted message string for the deprecated item.
+                             Omit to use the default.
+        :type message_func: callable
+        """
+        self.cli_ctx = cli_ctx
+        self.object_type = object_type
+        self.target = target
+        self.redirect = redirect
+        self.hide = hide
+        self.expiration = expiration
+
+        def _default_get_message(self):
+            message = "This {} has been deprecated and will be removed ".format(self.object_type)
+            if self.expiration:
+                message += "in version '{}'. ".format(self.expiration)
+            else:
+                message += 'in a future release. '
+            message += "Use '{}' instead. ".format(self.redirect) if self.redirect else ''
+            return message.lstrip()
+
+        # pylint: disable=unused-argument
+        def _default_get_tag(self):
+            return DEFAULT_DEPRECATED_TAG
+
+        self._get_tag = tag_func or _default_get_tag
+        self._get_message = message_func or _default_get_message
+
+    # pylint: disable=no-self-use
+    def _version_less_than_or_equal_to(self, v1, v2):
+        """ Returns true if v1 <= v2. """
+        if v1 == v2:
+            return True
+        v1_comps = v1.split('.')
+        v2_comps = v2.split('.')
+        if len(v1_comps) != len(v2_comps):
+            from knack.util import CLIError
+            raise CLIError("Unable to compare version '{}' to version '{}'. Check version format.".format(v1, v2))
+        for i, _ in enumerate(v1_comps):
+            if v1_comps[i] < v2_comps[i]:
+                return True
+            elif v1_comps[i] > v2_comps[i]:
+                return False
+        return False
+
+    def expired(self):
+        if self.expiration:
+            cli_version = self.cli_ctx.get_cli_version()
+            return self._version_less_than_or_equal_to(self.expiration, cli_version)
+        return False
+
+    def hidden(self):
+        hidden = False
+        if isinstance(self.hide, bool):
+            hidden = self.hide
+        elif isinstance(self.hide, str):
+            cli_version = self.cli_ctx.get_cli_version()
+            hidden = self._version_less_than_or_equal_to(self.hide, cli_version)
+        return hidden
+
+    def show_in_help(self):
+        return not self.hidden() and not self.expired()
+
+    @property
+    def tag(self):
+        """ Returns a tag object. """
+        return ColorizedString(self._get_tag(self), 'yellow')
+
+    @property
+    def message(self):
+        """ Returns a tuple with the formatted message string and the message length. """
+        return ColorizedString(self._get_message(self), 'yellow')
+
+
+class ImplicitDeprecated(Deprecated):
+
+    def __init__(self, **kwargs):
+
+        def get_implicit_deprecation_message(self):
+            message = "This {} is implicitly deprecated because command group '{}' is deprecated " \
+                "and will be removed ".format(self.object_type, self.target)
+            if self.expiration:
+                message += "in version '{}'. ".format(self.expiration)
+            else:
+                message += 'in a future release. '
+            message += "Use '{}' instead. ".format(self.redirect) if self.redirect else ''
+            return message.lstrip()
+
+        kwargs.update({
+            'tag_func': lambda _: '',
+            'message_func': get_implicit_deprecation_message
+        })
+        super(ImplicitDeprecated, self).__init__(**kwargs)

--- a/knack/help.py
+++ b/knack/help.py
@@ -8,8 +8,6 @@ import argparse
 import sys
 import textwrap
 
-import colorama
-
 from .deprecation import ImplicitDeprecated, resolve_deprecate_info
 from .log import get_logger
 from .util import CtxTypeError
@@ -20,11 +18,14 @@ logger = get_logger(__name__)
 
 
 FIRST_LINE_PREFIX = ' : '
-
-PREVIEW_TAG = colorama.Fore.CYAN + '[Preview]' + colorama.Fore.RESET
-PREVIEW_TAG_LEN = len(PREVIEW_TAG) - 2 * len(colorama.Fore.RESET)
-
 REQUIRED_TAG = '[Required]'
+
+
+def _get_preview_tag():
+    import colorama
+    PREVIEW_TAG = colorama.Fore.CYAN + '[Preview]' + colorama.Fore.RESET
+    PREVIEW_TAG_LEN = len(PREVIEW_TAG) - 2 * len(colorama.Fore.RESET)
+    return (PREVIEW_TAG, PREVIEW_TAG_LEN)
 
 
 def _get_hanging_indent(max_length, indent):
@@ -368,6 +369,7 @@ class CLIHelp(object):
         self.max_line_len = 0
 
         def _build_tags_string(item):
+            PREVIEW_TAG, PREVIEW_TAG_LEN = _get_preview_tag()
             deprecate_info = getattr(item, 'deprecate_info', None)
             deprecated = deprecate_info.tag if deprecate_info else ''
             preview = PREVIEW_TAG if getattr(item, 'preview_info', None) else ''
@@ -469,6 +471,7 @@ class CLIHelp(object):
             return None
 
         def _build_tags_string(item):
+            PREVIEW_TAG, PREVIEW_TAG_LEN = _get_preview_tag()
             deprecate_info = getattr(item, 'deprecate_info', None)
             deprecated = deprecate_info.tag if deprecate_info else ''
             preview = PREVIEW_TAG if getattr(item, 'preview_info', None) else ''
@@ -621,6 +624,7 @@ class CLIHelp(object):
         self.print_description_list(help_file.children)
 
     def show_help(self, cli_name, nouns, parser, is_group):
+        import colorama
         colorama.init(autoreset=True)
         delimiters = ' '.join(nouns)
         help_file = self.command_help_cls(self, delimiters, parser) if not is_group \

--- a/knack/help.py
+++ b/knack/help.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import argparse
 import sys
 import textwrap
@@ -306,7 +306,7 @@ class HelpParameter(HelpObject):  # pylint: disable=too-many-instance-attributes
 
     def update_from_data(self, data):
         if self.name != data.get('name'):
-            raise HelpAuthoringException("mismatched name {0} vs. {1}"
+            raise HelpAuthoringException(u"mismatched name {0} vs. {1}"
                                          .format(self.name,
                                                  data.get('name')))
 
@@ -339,7 +339,7 @@ class CLIHelp(object):
         _print_indent('Command' if help_file.type == 'command' else 'Group', indent)
 
         indent += 1
-        LINE_FORMAT = '{cli}{name}{separator}{summary}'
+        LINE_FORMAT = u'{cli}{name}{separator}{summary}'
         line = LINE_FORMAT.format(
             cli=cli_name,
             name=' ' + help_file.command if help_file.command else '',
@@ -359,7 +359,7 @@ class CLIHelp(object):
 
     def _print_groups(self, help_file):
 
-        LINE_FORMAT = '{name}{padding}{tags}{separator}{summary}'
+        LINE_FORMAT = u'{name}{padding}{tags}{separator}{summary}'
         indent = 1
 
         self.max_line_len = 0
@@ -389,7 +389,7 @@ class CLIHelp(object):
                 layout = {
                     'name': c.name,
                     'tags': tags,
-                    'separator': FIRST_LINE_PREFIX if (c.short_summary or tags) else '',
+                    'separator': FIRST_LINE_PREFIX if c.short_summary else '',
                     'summary': c.short_summary or '',
                     'line_len': line_len
                 }
@@ -421,13 +421,13 @@ class CLIHelp(object):
 
     @staticmethod
     def _get_choices_defaults_sources_str(p):
-        choice_str = '  Allowed values: {0}.'.format(', '.join(sorted([str(x) for x in p.choices]))) \
+        choice_str = u'  Allowed values: {0}.'.format(', '.join(sorted([str(x) for x in p.choices]))) \
             if p.choices else ''
-        default_str = '  Default: {0}.'.format(p.default) \
+        default_str = u'  Default: {0}.'.format(p.default) \
             if p.default and p.default != argparse.SUPPRESS else ''
-        value_sources_str = '  Values from: {0}.'.format(', '.join(p.value_sources)) \
+        value_sources_str = u'  Values from: {0}.'.format(', '.join(p.value_sources)) \
             if p.value_sources else ''
-        return '{0}{1}{2}'.format(choice_str, default_str, value_sources_str)
+        return u'{0}{1}{2}'.format(choice_str, default_str, value_sources_str)
 
     @staticmethod
     def print_description_list(help_files):
@@ -435,11 +435,11 @@ class CLIHelp(object):
         max_length = max(len(f.name) for f in help_files) if help_files else 0
         for help_file in sorted(help_files, key=lambda h: h.name):
             column_indent = max_length - len(help_file.name)
-            _print_indent('{0}{1}{2}'.format(help_file.name,
-                                             ' ' * column_indent,
-                                             FIRST_LINE_PREFIX + help_file.short_summary
-                                             if help_file.short_summary
-                                             else ''),
+            _print_indent(u'{0}{1}{2}'.format(help_file.name,
+                                              ' ' * column_indent,
+                                              FIRST_LINE_PREFIX + help_file.short_summary
+                                              if help_file.short_summary
+                                              else ''),
                           indent,
                           _get_hanging_indent(max_length, indent))
 
@@ -449,14 +449,14 @@ class CLIHelp(object):
         _print_indent('Examples', indent)
         for e in help_file.examples:
             indent = 1
-            _print_indent('{0}'.format(e.name), indent)
+            _print_indent(u'{0}'.format(e.name), indent)
             indent = 2
-            _print_indent('{0}'.format(e.text), indent)
+            _print_indent(u'{0}'.format(e.text), indent)
             print('')
 
     def _print_arguments(self, help_file):
 
-        LINE_FORMAT = '{name}{padding}{tags}{separator}{short_summary}'
+        LINE_FORMAT = u'{name}{padding}{tags}{separator}{short_summary}'
         indent = 1
         self.max_line_len = 0
 
@@ -497,7 +497,7 @@ class CLIHelp(object):
                 layout = {
                     'name': c.name,
                     'tags': tags,
-                    'separator': FIRST_LINE_PREFIX if (short_summary or tags) else '',
+                    'separator': FIRST_LINE_PREFIX if short_summary else '',
                     'short_summary': short_summary,
                     'long_summary': long_summary,
                     'group_name': c.group_name,
@@ -548,9 +548,9 @@ class CLIHelp(object):
         group_registry = ArgumentGroupRegistry([p.group_name for p in help_file.parameters if p.group_name])
 
         def _get_parameter_key(parameter):
-            return '{}{}{}'.format(group_registry.get_group_priority(parameter.group_name),
-                                   str(not parameter.required),
-                                   parameter.name)
+            return u'{}{}{}'.format(group_registry.get_group_priority(parameter.group_name),
+                                    str(not parameter.required),
+                                    parameter.name)
 
         parameter_layouts = _layout_items(help_file.parameters)
         _print_items(parameter_layouts)

--- a/knack/help.py
+++ b/knack/help.py
@@ -349,13 +349,16 @@ class CLIHelp(object):
         _print_indent(line, indent)
 
         def _build_long_summary(item):
-            long_summary = item.long_summary or ''
+            lines = []
+            if item.long_summary:
+                lines.append(item.long_summary)
             if item.deprecate_info:
-                long_summary += ' ' + str(item.deprecate_info.message)
-            return long_summary.lstrip().rstrip()
+                lines.append(str(item.deprecate_info.message))
+            return ' '.join(lines)
 
         indent += 1
-        _print_indent(_build_long_summary(help_file), indent)
+        long_sum = _build_long_summary(help_file)
+        _print_indent(long_sum, indent)
 
     def _print_groups(self, help_file):
 
@@ -539,11 +542,13 @@ class CLIHelp(object):
             return short_summary
 
         def _build_long_summary(item):
-            long_summary = item.long_summary.rstrip()
+            lines = []
+            if item.long_summary:
+                lines.append(item.long_summary)
             deprecate_info = getattr(item, 'deprecate_info', None)
             if deprecate_info:
-                long_summary += ' ' + str(deprecate_info.message)
-            return long_summary.lstrip().rstrip()
+                lines.append(str(item.deprecate_info.message))
+            return ' '.join(lines)
 
         group_registry = ArgumentGroupRegistry([p.group_name for p in help_file.parameters if p.group_name])
 
@@ -559,7 +564,7 @@ class CLIHelp(object):
 
     def _print_detailed_help(self, cli_name, help_file):
         self._print_header(cli_name, help_file)
-        if help_file.long_summary:
+        if help_file.long_summary or getattr(help_file, 'deprecate_info', None):
             _print_indent('')
 
         if help_file.type == 'command':

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import sys
 
 from collections import defaultdict
@@ -165,7 +167,8 @@ class CommandInvoker(object):
             deprecations.append(ImplicitDeprecated(**deprecate_kwargs))
 
         for d in deprecations:
-            logger.warning(str(d.message))
+            msg = str(d.message)
+            print(msg, file=sys.stderr)
 
         cmd_result = parsed_args.func(params)
         cmd_result = todict(cmd_result)

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -120,6 +120,7 @@ class CommandInvoker(object):
         cmd_tbl = self.commands_loader.load_command_table(args)
         command = self._rudimentary_get_command(args)
         self.commands_loader.load_arguments(command)
+
         self.cli_ctx.raise_event(EVENT_INVOKER_POST_CMD_TBL_CREATE, cmd_tbl=cmd_tbl)
         self.parser.load_command_table(self.commands_loader)
         self.cli_ctx.raise_event(EVENT_INVOKER_CMD_TBL_LOADED, parser=self.parser)

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -167,7 +167,7 @@ class CommandInvoker(object):
         colorama.init()
         for d in deprecations:
             print(d.message, file=sys.stderr)
-            colorama.deinit()
+        colorama.deinit()
 
         cmd_result = parsed_args.func(params)
         cmd_result = todict(cmd_result)

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -155,7 +155,7 @@ class CLICommandParser(argparse.ArgumentParser):
         """
         group_table = group_table or {}
         for length in range(0, len(path)):
-            parent_path = path[0:length]
+            parent_path = path[:length]
             parent_subparser = self.subparsers.get(tuple(parent_path), None)
             if not parent_subparser:
                 # No subparser exists for the given subpath - create and register
@@ -171,7 +171,7 @@ class CLICommandParser(argparse.ArgumentParser):
                     deprecate_info = command_group.group_kwargs.get('deprecate_info', None)
                     if deprecate_info and deprecate_info.expired():
                         continue
-                grandparent_path = path[0:length - 1]
+                grandparent_path = path[:length - 1]
                 grandparent_subparser = self.subparsers[tuple(grandparent_path)]
                 new_path = path[length - 1]
                 new_parser = grandparent_subparser.add_parser(new_path, cli_help=self.cli_help)

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -39,10 +39,9 @@ class CLICommandParser(argparse.ArgumentParser):
     @staticmethod
     def _add_argument(obj, arg):
         """ Only pass valid argparse kwargs to argparse.ArgumentParser.add_argument """
-        options_list = arg.options_list
         argparse_options = {name: value for name, value in arg.options.items() if name in ARGPARSE_SUPPORTED_KWARGS}
         scrubbed_options_list = []
-        for item in options_list:
+        for item in arg.options_list:
             if isinstance(item, Deprecated):
                 # don't add expired options to the parser
                 if item.expired():
@@ -120,7 +119,7 @@ class CLICommandParser(argparse.ArgumentParser):
             command_validator = metadata.validator
             argument_validators = []
             argument_groups = {}
-            for _, arg in metadata.arguments.items():
+            for arg in metadata.arguments.values():
 
                 # don't add deprecated arguments to the parser
                 deprecate_info = arg.type.settings.get('deprecate_info', None)

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -5,6 +5,7 @@
 
 import argparse
 
+from .deprecation import Deprecated
 from .events import EVENT_PARSER_GLOBAL_CREATE
 from .util import CtxTypeError
 
@@ -40,7 +41,23 @@ class CLICommandParser(argparse.ArgumentParser):
         """ Only pass valid argparse kwargs to argparse.ArgumentParser.add_argument """
         options_list = arg.options_list
         argparse_options = {name: value for name, value in arg.options.items() if name in ARGPARSE_SUPPORTED_KWARGS}
-        return obj.add_argument(*options_list, **argparse_options)
+        scrubbed_options_list = []
+        for item in options_list:
+            if isinstance(item, Deprecated):
+                # don't add expired options to the parser
+                if item.expired():
+                    continue
+
+                class _DeprecatedOption(str):
+                    def __new__(cls, *args, **kwargs):
+                        instance = str.__new__(cls, *args, **kwargs)
+                        return instance
+
+                option = _DeprecatedOption(item.target)
+                setattr(option, 'deprecate_info', item)
+                item = option
+            scrubbed_options_list.append(item)
+        return obj.add_argument(*scrubbed_options_list, **argparse_options)
 
     def __init__(self, cli_ctx=None, cli_help=None, **kwargs):
         """ Create the argument parser
@@ -63,12 +80,14 @@ class CLICommandParser(argparse.ArgumentParser):
         self._description = kwargs.pop('description', None)
         super(CLICommandParser, self).__init__(**kwargs)
 
-    def load_command_table(self, cmd_tbl):
+    def load_command_table(self, command_loader):
         """ Process the command table and load it into the parser
 
         :param cmd_tbl: A dictionary containing the commands
         :type cmd_tbl: dict
         """
+        cmd_tbl = command_loader.command_table
+        grp_tbl = command_loader.command_group_table
         if not cmd_tbl:
             raise ValueError('The command table is empty. At least one command is required.')
         # If we haven't already added a subparser, we
@@ -77,12 +96,16 @@ class CLICommandParser(argparse.ArgumentParser):
             sp = self.add_subparsers(dest='_command')
             sp.required = True
             self.subparsers = {(): sp}
+
         for command_name, metadata in cmd_tbl.items():
-            subparser = self._get_subparser(command_name.split())
+            subparser = self._get_subparser(command_name.split(), grp_tbl)
             command_verb = command_name.split()[-1]
             # To work around http://bugs.python.org/issue9253, we artificially add any new
             # parsers we add to the "choices" section of the subparser.
-            subparser.choices[command_verb] = command_verb
+            subparser = self._get_subparser(command_name.split(), grp_tbl)
+            deprecate_info = metadata.deprecate_info
+            if not subparser or (deprecate_info and deprecate_info.expired()):
+                continue
             # inject command_module designer's help formatter -- default is HelpFormatter
             fc = metadata.formatter_class or argparse.HelpFormatter
 
@@ -93,11 +116,17 @@ class CLICommandParser(argparse.ArgumentParser):
                                                   help_file=metadata.help,
                                                   formatter_class=fc,
                                                   cli_help=self.cli_help)
-
+            command_parser.cli_ctx = self.cli_ctx
             command_validator = metadata.validator
             argument_validators = []
             argument_groups = {}
-            for arg in metadata.arguments.values():
+            for _, arg in metadata.arguments.items():
+
+                # don't add deprecated arguments to the parser
+                deprecate_info = arg.type.settings.get('deprecate_info', None)
+                if deprecate_info and deprecate_info.expired():
+                    continue
+
                 if arg.validator:
                     argument_validators.append(arg.validator)
                 if arg.arg_group:
@@ -112,7 +141,7 @@ class CLICommandParser(argparse.ArgumentParser):
                 else:
                     param = CLICommandParser._add_argument(command_parser, arg)
                 param.completer = arg.completer
-
+                param.deprecate_info = arg.deprecate_info
             command_parser.set_defaults(
                 func=metadata,
                 command=command_name,
@@ -120,12 +149,14 @@ class CLICommandParser(argparse.ArgumentParser):
                 _argument_validators=argument_validators,
                 _parser=command_parser)
 
-    def _get_subparser(self, path):
+    def _get_subparser(self, path, group_table=None):
         """For each part of the path, walk down the tree of
         subparsers, creating new ones if one doesn't already exist.
         """
+        group_table = group_table or {}
         for length in range(0, len(path)):
-            parent_subparser = self.subparsers.get(tuple(path[0:length]), None)
+            parent_path = path[0:length]
+            parent_subparser = self.subparsers.get(tuple(parent_path), None)
             if not parent_subparser:
                 # No subparser exists for the given subpath - create and register
                 # a new subparser.
@@ -135,13 +166,25 @@ class CLICommandParser(argparse.ArgumentParser):
                 # with ensuring that a subparser for cmd exists, then for subcmd1,
                 # subcmd2 and so on), we know we can always back up one step and
                 # add a subparser if one doesn't exist
-                grandparent_subparser = self.subparsers[tuple(path[0:length - 1])]
-                new_parser = grandparent_subparser.add_parser(path[length - 1], cli_help=self.cli_help)
+                command_group = group_table.get(' '.join(parent_path))
+                if command_group:
+                    deprecate_info = command_group.group_kwargs.get('deprecate_info', None)
+                    if deprecate_info and deprecate_info.expired():
+                        continue
+                grandparent_path = path[0:length - 1]
+                grandparent_subparser = self.subparsers[tuple(grandparent_path)]
+                new_path = path[length - 1]
+                new_parser = grandparent_subparser.add_parser(new_path, cli_help=self.cli_help)
 
                 # Due to http://bugs.python.org/issue9253, we have to give the subparser
                 # a destination and set it to required in order to get a meaningful error
                 parent_subparser = new_parser.add_subparsers(dest='_subcommand')
+                command_group = group_table.get(' '.join(parent_path), None)
+                deprecate_info = None
+                if command_group:
+                    deprecate_info = command_group.group_kwargs.get('deprecate_info', None)
                 parent_subparser.required = True
+                parent_subparser.deprecate_info = deprecate_info
                 self.subparsers[tuple(path[0:length])] = parent_subparser
         return parent_subparser
 

--- a/knack/prompting.py
+++ b/knack/prompting.py
@@ -77,7 +77,6 @@ def prompt_t_f(msg, default=None, help_string=None):
     return _prompt_bool(msg, 't', 'f', default=default, help_string=help_string)
 
 
-# pylint: disable=inconsistent-return-statements
 def _prompt_bool(msg, true_str, false_str, default=None, help_string=None):
     verify_is_a_tty()
     if default not in [None, true_str, false_str]:
@@ -97,7 +96,6 @@ def _prompt_bool(msg, true_str, false_str, default=None, help_string=None):
             return default == y.lower()
 
 
-# pylint: disable=inconsistent-return-statements
 def prompt_choice_list(msg, a_list, default=1, help_string=None):
     """Prompt user to select from a list of possible choices.
 

--- a/knack/prompting.py
+++ b/knack/prompting.py
@@ -77,6 +77,7 @@ def prompt_t_f(msg, default=None, help_string=None):
     return _prompt_bool(msg, 't', 'f', default=default, help_string=help_string)
 
 
+# pylint: disable=inconsistent-return-statements
 def _prompt_bool(msg, true_str, false_str, default=None, help_string=None):
     verify_is_a_tty()
     if default not in [None, true_str, false_str]:
@@ -96,6 +97,7 @@ def _prompt_bool(msg, true_str, false_str, default=None, help_string=None):
             return default == y.lower()
 
 
+# pylint: disable=inconsistent-return-statements
 def prompt_choice_list(msg, a_list, default=1, help_string=None):
     """Prompt user to select from a list of possible choices.
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = '0.3.3'
+VERSION = '0.4.0'
 
 DEPENDENCIES = [
     'argcomplete',

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,262 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import sys
+import unittest
+import mock
+from six import StringIO
+
+
+from knack.arguments import ArgumentsContext
+from knack.commands import CLICommand, CLICommandsLoader, CommandGroup
+
+from tests.util import TestCLI
+
+io = {}
+
+
+def redirect_io(func):
+    def wrapper(self):
+        global io
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdout = sys.stderr = io = StringIO()
+        func(self)
+        io.close()
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+    return wrapper
+
+
+def example_handler(arg1, arg2=None, arg3=None):
+    """ Short summary here. Long summary here. Still long summary. """
+    pass
+
+
+class TestCommandDeprecation(unittest.TestCase):
+
+    def setUp(self):
+
+        from knack.help_files import helps
+
+        class DeprecationTestCommandLoader(CLICommandsLoader):
+            def load_command_table(self, args):
+                super(DeprecationTestCommandLoader, self).load_command_table(args)
+                with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
+                    g.command('cmd1', 'example_handler', deprecate_info=g.deprecate(redirect='alt-cmd1'))
+                    g.command('cmd2', 'example_handler', deprecate_info=g.deprecate(redirect='alt-cmd2', hide='1.0.0'))
+                    g.command('cmd3', 'example_handler', deprecate_info=g.deprecate(redirect='alt-cmd3', hide='0.1.0'))
+                    g.command('cmd4', 'example_handler', deprecate_info=g.deprecate(redirect='alt-cmd4', expiration='1.0.0'))
+                    g.command('cmd5', 'example_handler', deprecate_info=g.deprecate(redirect='alt-cmd5', expiration='0.1.0'))
+
+                with CommandGroup(self, 'group', '{}#{{}}'.format(__name__), deprecate_info=self.deprecate(redirect='alt-group')) as g:
+                    g.command('cmd1', 'example_handler')
+
+                return self.command_table
+
+            def load_arguments(self, command):
+                with ArgumentsContext(self, '') as c:
+                    c.argument('arg1', options_list=['--arg', '-a'], required=False, type=int, choices=[1, 2, 3])
+                    c.argument('arg2', options_list=['-b'], required=True, choices=['a', 'b', 'c'])
+
+                super(DeprecationTestCommandLoader, self).load_arguments(command)
+
+        helps['group'] = """
+    type: group
+    short-summary: A group.
+"""
+        self.cli_ctx = TestCLI(commands_loader_cls=DeprecationTestCommandLoader)
+
+    @redirect_io
+    def test_deprecate_command_group_help(self):
+        """ Ensure deprecated commands appear (or don't appear) correctly in group help view. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('-h'.split())
+        actual = io.getvalue()
+        expected = """
+Group
+    {}
+
+Subgroups:
+    group [Deprecated] : A group.
+
+Commands:
+    cmd1  [Deprecated] : Short summary here.
+    cmd2  [Deprecated] : Short summary here.
+    cmd4  [Deprecated] : Short summary here.
+
+""".format(self.cli_ctx.name)
+        self.assertEqual(expected, actual)
+
+    @redirect_io
+    def test_deprecate_command_help_hidden(self):
+        """ Ensure hidden deprecated command can be used. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('cmd3 -h'.split())
+        actual = io.getvalue()
+        expected = """
+Command
+    {} cmd3 : Short summary here.
+        Long summary here. Still long summary. This command has been deprecated and will be
+        removed in a future release. Use 'alt-cmd3' instead.
+
+Arguments
+    -b [Required] : Allowed values: a, b, c.
+    --arg -a      : Allowed values: 1, 2, 3.
+    --arg3
+""".format(self.cli_ctx.name)
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_command_expired(self):
+        """ Ensure expired command cannot be reached. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('cmd5 -h'.split())
+        actual = io.getvalue()
+        expected = "invalid choice: 'cmd5' (choose from 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'group')"
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_command_plain_execute(self):
+        """ Ensure general warning displayed when running deprecated command. """
+        self.cli_ctx.invoke('cmd1 -b b'.split())
+        actual = io.getvalue()
+        expected = "This command has been deprecated and will be removed in a future release. Use 'alt-cmd1' instead."
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_command_hidden_execute(self):
+        """ Ensure general warning displayed when running hidden deprecated command. """
+        self.cli_ctx.invoke('cmd3 -b b'.split())
+        actual = io.getvalue()
+        expected = "This command has been deprecated and will be removed in a future release. Use 'alt-cmd3' instead."
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_command_expiring_execute(self):
+        """ Ensure specific warning displayed when running expiring deprecated command. """
+        self.cli_ctx.invoke('cmd4 -b b'.split())
+        actual = io.getvalue()
+        expected = "This command has been deprecated and will be removed in version '1.0.0'. Use 'alt-cmd4' instead."
+        self.assertTrue(expected in actual)
+
+
+class TestCommandGroupDeprecation(unittest.TestCase):
+
+    def setUp(self):
+
+        from knack.help_files import helps
+
+        class DeprecationTestCommandLoader(CLICommandsLoader):
+            def load_command_table(self, args):
+                super(DeprecationTestCommandLoader, self).load_command_table(args)
+
+                with CommandGroup(self, 'group1', '{}#{{}}'.format(__name__), deprecate_info=self.deprecate(redirect='alt-group1')) as g:
+                    g.command('cmd1', 'example_handler')
+
+                with CommandGroup(self, 'group2', '{}#{{}}'.format(__name__), deprecate_info=self.deprecate(redirect='alt-group2', hide='1.0.0')) as g:
+                    g.command('cmd1', 'example_handler')
+
+                with CommandGroup(self, 'group3', '{}#{{}}'.format(__name__), deprecate_info=self.deprecate(redirect='alt-group3', hide='0.1.0')) as g:
+                    g.command('cmd1', 'example_handler')
+
+                with CommandGroup(self, 'group4', '{}#{{}}'.format(__name__), deprecate_info=self.deprecate(redirect='alt-group4', expiration='1.0.0')) as g:
+                    g.command('cmd1', 'example_handler')
+
+                with CommandGroup(self, 'group5', '{}#{{}}'.format(__name__), deprecate_info=self.deprecate(redirect='alt-group5', expiration='0.1.0')) as g:
+                    g.command('cmd1', 'example_handler')
+
+                return self.command_table
+
+            def load_arguments(self, command):
+                with ArgumentsContext(self, '') as c:
+                    c.argument('arg1', options_list=['--arg', '-a'], required=False, type=int, choices=[1, 2, 3])
+                    c.argument('arg2', options_list=['-b'], required=True, choices=['a', 'b', 'c'])
+
+                super(DeprecationTestCommandLoader, self).load_arguments(command)
+
+        helps['group1'] = """
+    type: group
+    short-summary: A group.
+"""
+        self.cli_ctx = TestCLI(commands_loader_cls=DeprecationTestCommandLoader)
+
+    @redirect_io
+    def test_deprecate_command_group_help_plain(self):
+        """ Ensure help warnings appear for deprecated command group help. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('group1 -h'.split())
+        actual = io.getvalue()
+        expected = """
+Group
+    cli group1 : A group.
+        This command group has been deprecated and will be removed in a future release. Use
+        'alt-group1' instead.
+
+Commands:
+    cmd1 : Short summary here.
+
+""".format(self.cli_ctx.name)
+        self.assertEqual(expected, actual)
+
+    @redirect_io
+    def test_deprecate_command_group_help_hidden(self):
+        """ Ensure hidden deprecated command can be used. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('group3 -h'.split())
+        actual = io.getvalue()
+        expected = """
+Group
+    {} group3
+        This command group has been deprecated and will be removed in a future release. Use
+        'alt-group3' instead.
+
+Commands:
+    cmd1 : Short summary here.
+
+""".format(self.cli_ctx.name)
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_command_group_help_expiring(self):
+        """ Ensure specific warning displayed when running expiring deprecated command. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('group4 -h'.split())
+        actual = io.getvalue()
+        expected = """
+Group
+    {} group4
+        This command group has been deprecated and will be removed in version '1.0.0'. Use
+        'alt-group4' instead.
+""".format(self.cli_ctx.name)
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_command_group_expired(self):
+        """ Ensure expired command cannot be reached. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('group5 -h'.split())
+        actual = io.getvalue()
+        expected = "invalid choice: 'group5' (choose from 'group1', 'group2', 'group3', 'group4')"
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_command_implicitly(self):
+        """ Ensure help warning displayed for command deprecated because of a deprecated parent group. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('group1 cmd1 -h'.split())
+        actual = io.getvalue()
+        expected = """
+Command
+    {} group1 cmd1 : Short summary here.
+        Long summary here. Still long summary. This command is implicitly deprecated because
+        command group 'group1' is deprecated and will be removed in a future release. Use 'alt-
+        group1' instead.
+""".format(self.cli_ctx.name)
+        self.assertTrue(expected in actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -3,36 +3,42 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from __future__ import unicode_literals
+
 import sys
 import unittest
 import mock
+from threading import Lock
 from six import StringIO
-
 
 from knack.arguments import ArgumentsContext
 from knack.commands import CLICommand, CLICommandsLoader, CommandGroup
 
 from tests.util import TestCLI
 
-io = {}
-
-
-def redirect_io(func):
-    def wrapper(self):
-        global io
-        old_stdout = sys.stdout
-        old_stderr = sys.stderr
-        sys.stdout = sys.stderr = io = StringIO()
-        func(self)
-        io.close()
-        sys.stdout = old_stdout
-        sys.stderr = old_stderr
-    return wrapper
-
 
 def example_handler(arg1, arg2=None, arg3=None):
     """ Short summary here. Long summary here. Still long summary. """
     pass
+
+
+def example_arg_handler(arg1, opt1, arg2=None, opt2=None, arg3=None,
+                        opt3=None, arg4=None, opt4=None, arg5=None, opt5=None):
+    pass
+
+
+original_stdout = sys.stdout
+original_stderr = sys.stderr
+
+
+def redirect_io(func):
+    def wrapper(self):
+        sys.stdout = sys.stderr = self.io = StringIO()
+        func(self)
+        self.io.close()
+        sys.stdout = original_stderr
+        sys.stderr = original_stderr
+    return wrapper
 
 
 class TestCommandDeprecation(unittest.TestCase):
@@ -51,7 +57,7 @@ class TestCommandDeprecation(unittest.TestCase):
                     g.command('cmd4', 'example_handler', deprecate_info=g.deprecate(redirect='alt-cmd4', expiration='1.0.0'))
                     g.command('cmd5', 'example_handler', deprecate_info=g.deprecate(redirect='alt-cmd5', expiration='0.1.0'))
 
-                with CommandGroup(self, 'group', '{}#{{}}'.format(__name__), deprecate_info=self.deprecate(redirect='alt-group')) as g:
+                with CommandGroup(self, 'grp1', '{}#{{}}'.format(__name__), deprecate_info=self.deprecate(redirect='alt-grp1')) as g:
                     g.command('cmd1', 'example_handler')
 
                 return self.command_table
@@ -63,7 +69,7 @@ class TestCommandDeprecation(unittest.TestCase):
 
                 super(DeprecationTestCommandLoader, self).load_arguments(command)
 
-        helps['group'] = """
+        helps['grp1'] = """
     type: group
     short-summary: A group.
 """
@@ -74,18 +80,18 @@ class TestCommandDeprecation(unittest.TestCase):
         """ Ensure deprecated commands appear (or don't appear) correctly in group help view. """
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('-h'.split())
-        actual = io.getvalue()
-        expected = """
+        actual = self.io.getvalue()
+        expected = u"""
 Group
     {}
 
 Subgroups:
-    group [Deprecated] : A group.
+    grp1 [Deprecated] : A group.
 
 Commands:
-    cmd1  [Deprecated] : Short summary here.
-    cmd2  [Deprecated] : Short summary here.
-    cmd4  [Deprecated] : Short summary here.
+    cmd1 [Deprecated] : Short summary here.
+    cmd2 [Deprecated] : Short summary here.
+    cmd4 [Deprecated] : Short summary here.
 
 """.format(self.cli_ctx.name)
         self.assertEqual(expected, actual)
@@ -95,7 +101,7 @@ Commands:
         """ Ensure hidden deprecated command can be used. """
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('cmd3 -h'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = """
 Command
     {} cmd3 : Short summary here.
@@ -110,19 +116,10 @@ Arguments
         self.assertTrue(expected in actual)
 
     @redirect_io
-    def test_deprecate_command_expired(self):
-        """ Ensure expired command cannot be reached. """
-        with self.assertRaises(SystemExit):
-            self.cli_ctx.invoke('cmd5 -h'.split())
-        actual = io.getvalue()
-        expected = "invalid choice: 'cmd5' (choose from 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'group')"
-        self.assertTrue(expected in actual)
-
-    @redirect_io
     def test_deprecate_command_plain_execute(self):
         """ Ensure general warning displayed when running deprecated command. """
         self.cli_ctx.invoke('cmd1 -b b'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = "This command has been deprecated and will be removed in a future release. Use 'alt-cmd1' instead."
         self.assertTrue(expected in actual)
 
@@ -130,7 +127,7 @@ Arguments
     def test_deprecate_command_hidden_execute(self):
         """ Ensure general warning displayed when running hidden deprecated command. """
         self.cli_ctx.invoke('cmd3 -b b'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = "This command has been deprecated and will be removed in a future release. Use 'alt-cmd3' instead."
         self.assertTrue(expected in actual)
 
@@ -138,9 +135,17 @@ Arguments
     def test_deprecate_command_expiring_execute(self):
         """ Ensure specific warning displayed when running expiring deprecated command. """
         self.cli_ctx.invoke('cmd4 -b b'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = "This command has been deprecated and will be removed in version '1.0.0'. Use 'alt-cmd4' instead."
         self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_command_expired_execute(self):
+        """ Ensure expired command cannot be reached. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('cmd5 -h'.split())
+        actual = self.io.getvalue()
+        self.assertTrue(u'invalid choice' in actual and u'cmd5' in actual)
 
 
 class TestCommandGroupDeprecation(unittest.TestCase):
@@ -188,7 +193,7 @@ class TestCommandGroupDeprecation(unittest.TestCase):
         """ Ensure help warnings appear for deprecated command group help. """
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('group1 -h'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = """
 Group
     cli group1 : A group.
@@ -206,7 +211,7 @@ Commands:
         """ Ensure hidden deprecated command can be used. """
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('group3 -h'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = """
 Group
     {} group3
@@ -224,7 +229,7 @@ Commands:
         """ Ensure specific warning displayed when running expiring deprecated command. """
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('group4 -h'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = """
 Group
     {} group4
@@ -238,16 +243,15 @@ Group
         """ Ensure expired command cannot be reached. """
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('group5 -h'.split())
-        actual = io.getvalue()
-        expected = "invalid choice: 'group5' (choose from 'group1', 'group2', 'group3', 'group4')"
-        self.assertTrue(expected in actual)
+        actual = self.io.getvalue()
+        self.assertTrue(u'invalid choice' in actual and u'group5' in actual)
 
     @redirect_io
     def test_deprecate_command_implicitly(self):
         """ Ensure help warning displayed for command deprecated because of a deprecated parent group. """
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('group1 cmd1 -h'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = """
 Command
     {} group1 cmd1 : Short summary here.
@@ -256,6 +260,173 @@ Command
         group1' instead.
 """.format(self.cli_ctx.name)
         self.assertTrue(expected in actual)
+
+
+class TestArgumentDeprecation(unittest.TestCase):
+
+    def setUp(self):
+
+        from knack.help_files import helps
+
+        class DeprecationTestCommandLoader(CLICommandsLoader):
+            def load_command_table(self, args):
+                super(DeprecationTestCommandLoader, self).load_command_table(args)
+                with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
+                    g.command('arg-test', 'example_arg_handler')
+                return self.command_table
+
+            def load_arguments(self, command):
+                with ArgumentsContext(self, 'arg-test') as c:
+                    c.argument('arg1', help='Arg1', deprecate_info=c.deprecate())
+                    c.argument('opt1', help='Opt1', options_list=['--opt1', c.deprecate(redirect='--opt1', target='--alt1')])
+                    c.argument('arg2', help='Arg2', deprecate_info=c.deprecate(hide='1.0.0'))
+                    c.argument('opt2', help='Opt2', options_list=['--opt2', c.deprecate(redirect='--opt2', target='--alt2', hide='1.0.0')])
+                    c.argument('arg3', help='Arg3', deprecate_info=c.deprecate(hide='0.1.0'))
+                    c.argument('opt3', help='Opt3', options_list=['--opt3', c.deprecate(redirect='--opt3', target='--alt3', hide='0.1.0')])
+                    c.argument('arg4', deprecate_info=c.deprecate(expiration='1.0.0'))
+                    c.argument('opt4', options_list=['--opt4', c.deprecate(redirect='--opt4', target='--alt4', expiration='1.0.0')])
+                    c.argument('arg5', deprecate_info=c.deprecate(expiration='0.1.0'))
+                    c.argument('opt5', options_list=['--opt5', c.deprecate(redirect='--opt5', target='--alt5', expiration='0.1.0')])
+
+                super(DeprecationTestCommandLoader, self).load_arguments(command)
+
+        helps['grp1'] = """
+    type: group
+    short-summary: A group.
+"""
+        self.cli_ctx = TestCLI(commands_loader_cls=DeprecationTestCommandLoader)
+
+    @redirect_io
+    def test_deprecate_arguments_command_help(self):
+        """ Ensure deprecated arguments and options appear (or don't appear)
+        correctly in command help view. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('arg-test -h'.split())
+        actual = self.io.getvalue()
+        expected = """
+Command
+    {} arg-test
+
+Arguments
+    --alt1 [Deprecated] [Required] : Opt1.
+        Option '--alt1' has been deprecated and will be removed in a future release. Use '--
+        opt1' instead.
+    --arg1 [Deprecated] [Required] : Arg1.
+        Argument 'arg1' has been deprecated and will be removed in a future release.
+    --opt1              [Required] : Opt1.
+    --alt2            [Deprecated] : Opt2.
+        Option '--alt2' has been deprecated and will be removed in a future release. Use '--
+        opt2' instead.
+    --alt4            [Deprecated]
+        Option '--alt4' has been deprecated and will be removed in version '1.0.0'. Use '--
+        opt4' instead.
+    --arg2            [Deprecated] : Arg2.
+        Argument 'arg2' has been deprecated and will be removed in a future release.
+    --arg4            [Deprecated]
+        Argument 'arg4' has been deprecated and will be removed in version '1.0.0'.
+    --opt2                         : Opt2.
+    --opt3                         : Opt3.
+    --opt4
+    --opt5
+""".format(self.cli_ctx.name)
+        self.assertTrue(actual.startswith(expected))
+
+    @redirect_io
+    def test_deprecate_arguments_execute(self):
+        """ Ensure deprecated arguments can be used. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Argument 'arg1' has been deprecated and will be removed in a future release."
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_arguments_execute_hidden(self):
+        """ Ensure hidden deprecated arguments can be used. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --arg3 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Argument 'arg3' has been deprecated and will be removed in a future release."
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_arguments_execute_expiring(self):
+        """ Ensure hidden deprecated arguments can be used. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --arg4 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Argument 'arg4' has been deprecated and will be removed in version '1.0.0'."
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_arguments_execute_expired(self):
+        """ Ensure expired deprecated arguments can't be used. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --arg5 foo'.split())
+        actual = self.io.getvalue()
+        expected = 'unrecognized arguments: --arg5 foo'
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_options_execute(self):
+        """ Ensure deprecated options can be used with a warning. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --alt1 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Option '--alt1' has been deprecated and will be removed in a future release. Use '--opt1' instead."
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_options_execute_non_deprecated(self):
+        """ Ensure non-deprecated options don't show warning. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Option '--alt1' has been deprecated and will be removed in a future release. Use '--opt1' instead."
+        self.assertTrue(expected not in actual)
+
+    @redirect_io
+    def test_deprecate_options_execute_hidden(self):
+        """ Ensure hidden deprecated options can be used with warning. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --alt3 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Option '--alt3' has been deprecated and will be removed in a future release. Use '--opt3' instead."
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_options_execute_hidden_non_deprecated(self):
+        """ Ensure hidden non-deprecated optionss can be used without warning. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --opt3 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Option '--alt3' has been deprecated and will be removed in a future release. Use '--opt3' instead."
+        self.assertTrue(expected not in actual)
+
+    @redirect_io
+    def test_deprecate_options_execute_expired(self):
+        """ Ensure expired deprecated options can't be used. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --alt5 foo'.split())
+        actual = self.io.getvalue()
+        expected = 'unrecognized arguments: --alt5 foo'
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_options_execute_expired_non_deprecated(self):
+        """ Ensure non-expired options can be used without warning. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --opt5 foo'.split())
+        actual = self.io.getvalue()
+        self.assertTrue(u'--alt5' not in actual and u'--opt5' not in actual)
+
+    @redirect_io
+    def test_deprecate_options_execute_expiring(self):
+        """ Ensure expiring options can be used with warning. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --alt4 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Option '--alt4' has been deprecated and will be removed in version '1.0.0'. Use '--opt4' instead."
+        self.assertTrue(expected in actual)
+
+    @redirect_io
+    def test_deprecate_options_execute_expiring_non_deprecated(self):
+        """ Ensure non-expiring options can be used without warning. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --opt4 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Option '--alt4' has been deprecated and will be removed in version '1.0.0'. Use '--opt4' instead."
+        self.assertTrue(expected not in actual)
 
 
 if __name__ == '__main__':

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -150,6 +150,22 @@ class TestHelp(unittest.TestCase):
             self.assertTrue(io.getvalue().startswith('\nCommand\n    {} n1: Short description.\n        Long description.'.format(self.cliname)))  # pylint: disable=line-too-long
 
     @redirect_io
+    def test_help_description_from_docstring(self):
+        def test_handler():
+            """ Short summary here. Long summary here. Still long summary. """
+            pass
+
+        command = CLICommand(self.mock_ctx, 'n1', test_handler)
+        cmd_table = {'n1': command}
+        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
+            with self.assertRaises(SystemExit):
+                self.mock_ctx.invoke('n1 -h'.split())
+            actual = io.getvalue()
+            expected = '\nCommand\n    {} n1: Short summary here.\n        Long summary here. Still long summary.'.format(self.cliname)
+            msg = 'ACT: {}\nEXP: {}'.format(actual, expected)
+            self.fail(msg)
+
+    @redirect_io
     def test_help_docstring_description_overrides_short_description(self):
         def test_handler():
             pass

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -10,10 +10,12 @@ from six import StringIO
 
 
 from knack.help import ArgumentGroupRegistry, HelpObject
-from knack.commands import CLICommand, CLICommandsLoader
+from knack.arguments import ArgumentsContext
+from knack.commands import CLICommand, CLICommandsLoader, CommandGroup
 from knack.events import EVENT_PARSER_GLOBAL_CREATE
+from knack.invocation import CommandInvoker
 
-from tests.util import MockContext
+from tests.util import MockContext, TestCLI
 
 io = {}
 
@@ -29,6 +31,11 @@ def redirect_io(func):
         sys.stdout = old_stdout
         sys.stderr = old_stderr
     return wrapper
+
+
+def example_handler(arg1, arg2=None, arg3=None):
+    """ Short summary here. Long summary here. Still long summary. """
+    pass
 
 
 class TestHelpArgumentGroupRegistry(unittest.TestCase):
@@ -69,444 +76,382 @@ class TestHelpObject(unittest.TestCase):
 class TestHelp(unittest.TestCase):
 
     def setUp(self):
-        self.mock_ctx = MockContext()
-        self.cliname = self.mock_ctx.name
+
+        from knack.help_files import helps
+
+        class HelpTestCommandLoader(CLICommandsLoader):
+            def load_command_table(self, args):
+                super(HelpTestCommandLoader, self).load_command_table(args)
+                with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
+                    g.command('n1', 'example_handler')
+                    g.command('n2', 'example_handler')
+                    g.command('n3', 'example_handler')
+                    g.command('n4', 'example_handler')
+                    g.command('n5', 'example_handler')
+
+                with CommandGroup(self, 'group alpha', '{}#{{}}'.format(__name__)) as g:
+                    g.command('n1', 'example_handler')
+
+                with CommandGroup(self, 'group beta', '{}#{{}}'.format(__name__)) as g:
+                    g.command('n1', 'example_handler')
+
+                return self.command_table
+
+            def load_arguments(self, command):
+                for scope in ['n1', 'group alpha', 'group beta']:
+                    with ArgumentsContext(self, scope) as c:
+                        c.argument('arg1', options_list=['--arg', '-a'], required=False, type=int, choices=[1, 2, 3])
+                        c.argument('arg2', options_list=['-b'], required=True, choices=['a', 'b', 'c'])
+
+                for scope in ['n4', 'n5']:
+                    with ArgumentsContext(self, scope) as c:
+                        c.argument('arg1', options_list=['--foobar'])
+                        c.argument('arg2', options_list=['--foobar2'], required=True)
+                        c.argument('arg3', options_list=['--foobar3'], help='the foobar3')
+
+                super(HelpTestCommandLoader, self).load_arguments(command)
+
+        helps['n2'] = """
+    type: command
+    short-summary: YAML short summary.
+    long-summary: YAML long summary. More summary.
+"""
+
+        helps['n3'] = """
+    type: command
+    long-summary: |
+        line1
+        line2
+"""
+
+        helps['n4'] = """
+    type: command
+    parameters:
+        - name: --foobar
+          type: string
+          required: false
+          short-summary: one line partial sentence
+          long-summary: text, markdown, etc.
+          populator-commands:
+            - mycli abc xyz
+            - default
+        - name: --foobar2
+          type: string
+          required: true
+          short-summary: one line partial sentence
+          long-summary: paragraph(s)
+"""
+
+        helps['n5'] = """
+    type: command
+    short-summary: this module does xyz one-line or so
+    long-summary: |
+        this module.... kjsdflkj... klsfkj paragraph1
+        this module.... kjsdflkj... klsfkj paragraph2
+    parameters:
+        - name: --foobar
+          type: string
+          required: false
+          short-summary: one line partial sentence
+          long-summary: text, markdown, etc.
+          populator-commands:
+            - mycli abc xyz
+            - default
+        - name: --foobar2
+          type: string
+          required: true
+          short-summary: one line partial sentence
+          long-summary: paragraph(s)
+    examples:
+        - name: foo example
+          text: example details
+"""
+
+        helps['group alpha'] = """
+    type: group
+    short-summary: this module does xyz one-line or so
+    long-summary: |
+        this module.... kjsdflkj... klsfkj paragraph1
+        this module.... kjsdflkj... klsfkj paragraph2
+"""
+
+        helps['group alpha n1'] = """
+    short-summary: this module does xyz one-line or so
+    long-summary: |
+        this module.... kjsdflkj... klsfkj paragraph1
+        this module.... kjsdflkj... klsfkj paragraph2
+    parameters:
+        - name: --arg -a
+          type: string
+          required: false
+          short-summary: one line partial sentence
+          long-summary: text, markdown, etc.
+          populator-commands:
+            - mycli abc xyz
+            - default
+        - name: -b
+          type: string
+          required: true
+          short-summary: one line partial sentence
+          long-summary: paragraph(s)
+    examples:
+        - name: foo example
+          text: example details
+"""
+
+        self.cli_ctx = TestCLI(commands_loader_cls=HelpTestCommandLoader)
 
     @redirect_io
     def test_choice_list_with_ints(self):
-        def test_handler():
-            pass
-
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        command.add_argument('arg', '--arg', '-a', required=False, choices=[1, 2, 3])
-        command.add_argument('b', '-b', required=False, choices=['a', 'b', 'c'])
-        cmd_table = {'n1': command}
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
+        """ Ensure choice_list works with integer lists. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n1 -h'.split())
+        actual = io.getvalue()
+        expected = 'Allowed values: 1, 2, 3'
+        self.assertTrue(expected in actual)
 
     @redirect_io
     def test_help_param(self):
-        def test_handler():
-            pass
+        """ Ensure both --help and -h produce the same output. """
 
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        command.add_argument('arg', '--arg', '-a', required=False)
-        command.add_argument('b', '-b', required=False)
-        cmd_table = {'n1': command}
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n1 -h'.split())
 
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 --help'.split())
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n1 --help'.split())
 
     @redirect_io
-    def test_help_plain_short_description(self):
-        def test_handler():
-            pass
+    def test_help_long_and_short_description_from_docstring(self):
+        """ Ensure the first sentence of a docstring is parsed as the short summary and subsequent text is interpretted
+        as the long summary. """
 
-        command = CLICommand(self.mock_ctx, 'n1', test_handler, description='the description')
-        command.add_argument('arg', '--arg', '-a', required=False)
-        command.add_argument('b', '-b', required=False)
-        cmd_table = {'n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-            self.assertTrue('n1: The description.' in io.getvalue())
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n1 -h'.split())
+        actual = io.getvalue()
+        expected = '\nCommand\n    {} n1 : Short summary here.\n        Long summary here. Still long summary.'.format(self.cli_ctx.name)
+        self.assertTrue(actual.startswith(expected))
 
     @redirect_io
-    def test_help_plain_long_description(self):
-        def test_handler():
-            pass
+    def test_help_long_and_short_description_from_yaml(self):
+        """ Ensure the YAML version of short and long summary display correctly and override any values that may
+        have been obtained through reflection. """
 
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        command.add_argument('arg', '--arg', '-a', required=False)
-        command.add_argument('b', '-b', required=False)
-        command.help = 'long description'
-        cmd_table = {'n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-            self.assertTrue(io.getvalue().startswith('\nCommand\n    {} n1\n        Long description.'.format(self.cliname)))
-
-    @redirect_io
-    def test_help_long_description_and_short_description(self):
-        def test_handler():
-            pass
-
-        command = CLICommand(self.mock_ctx, 'n1', test_handler, description='short description')
-        command.add_argument('arg', '--arg', '-a', required=False)
-        command.add_argument('b', '-b', required=False)
-        command.help = 'long description'
-        cmd_table = {'n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-            self.assertTrue(io.getvalue().startswith('\nCommand\n    {} n1: Short description.\n        Long description.'.format(self.cliname)))  # pylint: disable=line-too-long
-
-    @redirect_io
-    def test_help_description_from_docstring(self):
-        def test_handler():
-            """ Short summary here. Long summary here. Still long summary. """
-            pass
-
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        cmd_table = {'n1': command}
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-            actual = io.getvalue()
-            expected = '\nCommand\n    {} n1: Short summary here.\n        Long summary here. Still long summary.'.format(self.cliname)
-            msg = 'ACT: {}\nEXP: {}'.format(actual, expected)
-            self.fail(msg)
-
-    @redirect_io
-    def test_help_docstring_description_overrides_short_description(self):
-        def test_handler():
-            pass
-
-        command = CLICommand(self.mock_ctx, 'n1', test_handler, description='short description')
-        command.add_argument('arg', '--arg', '-a', required=False)
-        command.add_argument('b', '-b', required=False)
-        command.help = 'short-summary: docstring summary'
-        cmd_table = {'n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-            self.assertTrue('n1: Docstring summary.' in io.getvalue())
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n2 -h'.split())
+        actual = io.getvalue()
+        expected = '\nCommand\n    {} n2 : YAML short summary.\n        YAML long summary. More summary.'.format(self.cli_ctx.name)
+        self.assertTrue(actual.startswith(expected))
 
     @redirect_io
     def test_help_long_description_multi_line(self):
-        def test_handler():
-            pass
+        """ Ensure that multi-line help in the YAML is displayed correctly. """
 
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        command.add_argument('arg', '--arg', '-a', required=False)
-        command.add_argument('b', '-b', required=False)
-        command.help = """
-            long-summary: |
-                line1
-                line2
-            """
-        cmd_table = {'n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-
-            self.assertTrue(io.getvalue().startswith('\nCommand\n    {} n1\n        Line1\n        line2.'.format(self.cliname)))  # pylint: disable=line-too-long
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n3 -h'.split())
+        actual = io.getvalue()
+        expected = '\nCommand\n    {} n3 : Short summary here.\n        Line1\n        line2.\n'.format(self.cli_ctx.name)
+        self.assertTrue(actual.startswith(expected))
 
     @redirect_io
-    @mock.patch('knack.cli.CLI.register_event')
-    def test_help_params_documentations(self, _):
-        def test_handler():
-            pass
+    def test_help_params_documentations(self):
+        """ Ensure argument help is rendered according to the YAML spec. """
 
-        self.mock_ctx = MockContext()
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        command.add_argument('foobar', '--foobar', '-fb', required=False)
-        command.add_argument('foobar2', '--foobar2', '-fb2', required=True)
-        command.add_argument('foobar3', '--foobar3', '-fb3', required=False, help='the foobar3')
-        command.help = """
-            parameters:
-                - name: --foobar -fb
-                  type: string
-                  required: false
-                  short-summary: one line partial sentence
-                  long-summary: text, markdown, etc.
-                  populator-commands:
-                    - mycli abc xyz
-                    - default
-                - name: --foobar2 -fb2
-                  type: string
-                  required: true
-                  short-summary: one line partial sentence
-                  long-summary: paragraph(s)
-            """
-        cmd_table = {'n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-        s = """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n4 -h'.split())
+        expected = """
 Command
-    {} n1
+    {} n4 : Short summary here.
 
 Arguments
-    --foobar2 -fb2 [Required]: One line partial sentence.
-        Paragraph(s).
-    --foobar -fb             : One line partial sentence.  Values from: mycli abc xyz, default.
+    --foobar  [Required] : One line partial sentence.  Values from: mycli abc xyz, default.
         Text, markdown, etc.
-    --foobar3 -fb3           : The foobar3.
-
-Global Arguments
-    --help -h                : Show this help message and exit.
+    --foobar2 [Required] : One line partial sentence.
+        Paragraph(s).
+    --foobar3            : The foobar3.
 """
-        self.assertEqual(s.format(self.cliname), io.getvalue())
+        actual = io.getvalue()
+        expected = expected.format(self.cli_ctx.name)
+        self.assertTrue(actual.startswith(expected))
 
     @redirect_io
-    @mock.patch('knack.cli.CLI.register_event')
-    def test_help_full_documentations(self, _):
-        def test_handler():
-            pass
+    def test_help_full_documentations(self):
+        """ Test all features of YAML format. """
 
-        self.mock_ctx = MockContext()
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        command.add_argument('foobar', '--foobar', '-fb', required=False)
-        command.add_argument('foobar2', '--foobar2', '-fb2', required=True)
-        command.help = """
-                short-summary: this module does xyz one-line or so
-                long-summary: |
-                    this module.... kjsdflkj... klsfkj paragraph1
-                    this module.... kjsdflkj... klsfkj paragraph2
-                parameters:
-                    - name: --foobar -fb
-                      type: string
-                      required: false
-                      short-summary: one line partial sentence
-                      long-summary: text, markdown, etc.
-                      populator-commands:
-                        - mycli abc xyz
-                        - default
-                    - name: --foobar2 -fb2
-                      type: string
-                      required: true
-                      short-summary: one line partial sentence
-                      long-summary: paragraph(s)
-                examples:
-                    - name: foo example
-                      text: example details
-            """
-        cmd_table = {'n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-        s = """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n5 -h'.split())
+        expected = """
 Command
-    {} n1: This module does xyz one-line or so.
+    {} n5 : This module does xyz one-line or so.
         This module.... kjsdflkj... klsfkj paragraph1
         this module.... kjsdflkj... klsfkj paragraph2.
 
 Arguments
-    --foobar2 -fb2 [Required]: One line partial sentence.
-        Paragraph(s).
-    --foobar -fb             : One line partial sentence.  Values from: mycli abc xyz, default.
+    --foobar  [Required] : One line partial sentence.  Values from: mycli abc xyz, default.
         Text, markdown, etc.
+    --foobar2 [Required] : One line partial sentence.
+        Paragraph(s).
+    --foobar3            : The foobar3.
 
 Global Arguments
-    --help -h                : Show this help message and exit.
+    --debug              : Increase logging verbosity to show all debug logs.
+    --help -h            : Show this help message and exit.
+    --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
+    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+                           examples.
+    --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
 Examples
     foo example
         example details
 
 """
-        self.assertEqual(s.format(self.cliname), io.getvalue())
+        actual = io.getvalue()
+        expected = expected.format(self.cli_ctx.name)
+        self.assertTrue(actual.startswith(expected))
 
     @redirect_io
-    @mock.patch('knack.cli.CLI.register_event')
-    def test_help_with_param_specified(self, _):
-        def test_handler():
-            pass
+    def test_help_with_param_specified(self):
+        """ Ensure help appears even if some arguments are specified. """
 
-        self.mock_ctx = MockContext()
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        command.add_argument('arg', '--arg', '-a', required=False)
-        command.add_argument('b', '-b', required=False)
-        cmd_table = {'n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 --arg foo -h'.split())
-
-        s = """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n1 --arg 1 -h'.split())
+        expected = """
 Command
-    {} n1
+    {} n1 : Short summary here.
+        Long summary here. Still long summary.
 
 Arguments
-    --arg -a
-    -b
+    -b [Required] : Allowed values: a, b, c.
+    --arg -a      : Allowed values: 1, 2, 3.
+    --arg3
 
 Global Arguments
-    --help -h: Show this help message and exit.
-"""
+    --debug       : Increase logging verbosity to show all debug logs.
+    --help -h     : Show this help message and exit.
+    --output -o   : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
+    --query       : JMESPath query string. See http://jmespath.org/ for more information and
+                    examples.
+    --verbose     : Increase logging verbosity. Use --debug for full debug logs.
 
-        self.assertEqual(s.format(self.cliname), io.getvalue())
+"""
+        actual = io.getvalue()
+        expected = expected.format(self.cli_ctx.name)
+        self.assertEqual(actual, expected)
 
     @redirect_io
     def test_help_group_children(self):
-        def test_handler():
-            pass
+        """ Ensure subgroups appear correctly. """
 
-        def test_handler2():
-            pass
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('group -h'.split())
 
-        command = CLICommand(self.mock_ctx, 'group1 group3 n1', test_handler)
-        command.add_argument('foobar', '--foobar', '-fb', required=False)
-        command.add_argument('foobar2', '--foobar2', '-fb2', required=True)
+        expected = """
+Group
+    {} group
 
-        command2 = CLICommand(self.mock_ctx, 'group1 group2 n1', test_handler2)
-        command2.add_argument('foobar', '--foobar', '-fb', required=False)
-        command2.add_argument('foobar2', '--foobar2', '-fb2', required=True)
+Subgroups:
+    alpha : This module does xyz one-line or so.
+    beta
 
-        cmd_table = {'group1 group3 n1': command, 'group1 group2 n1': command2}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('group1 -h'.split())
-            s = '\nGroup\n    {} group1\n\nSubgroups:\n    group2\n    group3\n\n'.format(self.cliname)
-            self.assertEqual(s, io.getvalue())
+"""
+        actual = io.getvalue()
+        expected = expected.format(self.cli_ctx.name)
+        self.assertEqual(actual, expected)
 
     @redirect_io
-    def test_help_extra_missing_params(self):
-        def test_handler(foobar2, foobar=None):  # pylint: disable=unused-argument
-            pass
+    def test_help_missing_params(self):
+        """ Ensure the appropriate error is thrown when a required argument is missing. """
 
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        command.add_argument('foobar', '--foobar', '-fb', required=False)
-        command.add_argument('foobar2', '--foobar2', '-fb2', required=True)
-        cmd_table = {'n1': command}
+        # work around an argparse behavior where output is not printed and SystemExit
+        # is not raised on Python 2.7.9
+        if sys.version_info < (2, 7, 10):
+            try:
+                self.cli_ctx.invoke('n1 -a 1 --arg 2'.split())
+            except SystemExit:
+                pass
+        else:
+            with self.assertRaises(SystemExit):
+                self.cli_ctx.invoke('n1 -a 1 --arg 2'.split())
 
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            # work around an argparse behavior where output is not printed and SystemExit
-            # is not raised on Python 2.7.9
-            if sys.version_info < (2, 7, 10):
-                try:
-                    self.mock_ctx.invoke('n1 -fb a --foobar value'.split())
-                except SystemExit:
-                    pass
+            actual = io.getvalue()
+            self.assertTrue('required' in actual and '-b' in actual)
 
-                try:
-                    self.mock_ctx.invoke('n1 -fb a --foobar2 value --foobar3 extra'.split())
-                except SystemExit:
-                    pass
-            else:
-                with self.assertRaises(SystemExit):
-                    self.mock_ctx.invoke('n1 -fb a --foobar value'.split())
-                with self.assertRaises(SystemExit):
-                    self.mock_ctx.invoke('n1 -fb a --foobar2 value --foobar3 extra'.split())
+    @redirect_io
+    def test_help_extra_params(self):
+        """ Ensure appropriate error is thrown when an extra argument is used. """
 
-                self.assertTrue('required' in io.getvalue() and
-                                '--foobar/-fb' not in io.getvalue() and
-                                '--foobar2/-fb2' in io.getvalue() and
-                                'unrecognized arguments: --foobar3 extra' in io.getvalue())
+        # work around an argparse behavior where output is not printed and SystemExit
+        # is not raised on Python 2.7.9
+        if sys.version_info < (2, 7, 10):
+            try:
+                self.cli_ctx.invoke('n1 -a 1 -b c -c extra'.split())
+            except SystemExit:
+                pass
+        else:
+            with self.assertRaises(SystemExit):
+                self.cli_ctx.invoke('n1 -a 1 -b c -c extra'.split())
+
+        actual = io.getvalue()
+        expected = 'unrecognized arguments: -c extra'
+        self.assertTrue(expected in actual)
 
     @redirect_io
     def test_help_group_help(self):
-        def test_handler():
-            pass
-        from knack.help_files import helps
-        helps['test_group1 test_group2'] = """
-            type: group
-            short-summary: this module does xyz one-line or so
-            long-summary: |
-                this module.... kjsdflkj... klsfkj paragraph1
-                this module.... kjsdflkj... klsfkj paragraph2
-            examples:
-                - name: foo example
-                  text: example details
-            """
+        """ Ensure group help appears correctly. """
 
-        command = CLICommand(self.mock_ctx, 'test_group1 test_group2 n1', test_handler)
-        command.add_argument('foobar', '--foobar', '-fb', required=False)
-        command.add_argument('foobar2', '--foobar2', '-fb2', required=True)
-        command.help = """
-            short-summary: this module does xyz one-line or so
-            long-summary: |
-                this module.... kjsdflkj... klsfkj paragraph1
-                this module.... kjsdflkj... klsfkj paragraph2
-            parameters:
-                - name: --foobar -fb
-                  type: string
-                  required: false
-                  short-summary: one line partial sentence
-                  long-summary: text, markdown, etc.
-                  populator-commands:
-                    - mycli abc xyz
-                    - default
-                - name: --foobar2 -fb2
-                  type: string
-                  required: true
-                  short-summary: one line partial sentence
-                  long-summary: paragraph(s)
-            examples:
-                - name: foo example
-                  text: example details
-        """
-        cmd_table = {'test_group1 test_group2 n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('test_group1 test_group2 --help'.split())
-        s = """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('group alpha -h'.split())
+        expected = """
 Group
-    {} test_group1 test_group2: This module does xyz one-line or so.
+    {} group alpha : This module does xyz one-line or so.
         This module.... kjsdflkj... klsfkj paragraph1
         this module.... kjsdflkj... klsfkj paragraph2.
 
 Commands:
-    n1: This module does xyz one-line or so.
-
-
-Examples
-    foo example
-        example details
+    n1 : This module does xyz one-line or so.
 
 """
-        self.assertEqual(s.format(self.cliname), io.getvalue())
-        del helps['test_group1 test_group2']
+        actual = io.getvalue()
+        expected = expected.format(self.cli_ctx.name)
+        self.assertEqual(actual, expected)
 
     @redirect_io
     @mock.patch('knack.cli.CLI.register_event')
     def test_help_global_params(self, _):
+        """ Ensure global parameters can be added and display correctly. """
 
         def register_globals(_, **kwargs):
             arg_group = kwargs.get('arg_group')
             arg_group.add_argument('--exampl',
                                    help='This is a new global argument.')
 
-        self.mock_ctx = MockContext()
-        self.mock_ctx._event_handlers[EVENT_PARSER_GLOBAL_CREATE].append(register_globals)  # pylint: disable=protected-access
+        self.cli_ctx._event_handlers[EVENT_PARSER_GLOBAL_CREATE].append(register_globals)  # pylint: disable=protected-access
 
-        def test_handler():
-            pass
-
-        command = CLICommand(self.mock_ctx, 'n1', test_handler)
-        command.add_argument('arg', '--arg', '-a', required=False)
-        command.add_argument('b', '-b', required=False)
-        command.help = """
-            long-summary: |
-                line1
-                line2
-        """
-        cmd_table = {'n1': command}
-
-        with mock.patch.object(CLICommandsLoader, 'load_command_table', return_value=cmd_table):
-            with self.assertRaises(SystemExit):
-                self.mock_ctx.invoke('n1 -h'.split())
-
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('n1 -h'.split())
         s = """
 Command
-    {} n1
-        Line1
-        line2.
+    {} n1 : Short summary here.
+        Long summary here. Still long summary.
 
 Arguments
-    --arg -a
-    -b
+    -b [Required] : Allowed values: a, b, c.
+    --arg -a      : Allowed values: 1, 2, 3.
+    --arg3
 
 Global Arguments
-    --exampl : This is a new global argument.
-    --help -h: Show this help message and exit.
+    --debug       : Increase logging verbosity to show all debug logs.
+    --exampl      : This is a new global argument.
+    --help -h     : Show this help message and exit.
+    --output -o   : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
+    --query       : JMESPath query string. See http://jmespath.org/ for more information and
+                    examples.
+    --verbose     : Increase logging verbosity. Use --debug for full debug logs.
+
 """
-        self.assertEqual(s.format(self.cliname), io.getvalue())
+        actual = io.getvalue()
+        expected = s.format(self.cli_ctx.name)
+        self.assertEqual(actual, expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,9 +30,10 @@ class TestParser(unittest.TestCase):
         command = CLICommand(self.mock_ctx, 'command the-name', test_handler1)
         command2 = CLICommand(self.mock_ctx, 'sub-command the-second-name', test_handler2)
         cmd_table = {'command the-name': command, 'sub-command the-second-name': command2}
+        self.mock_ctx.commands_loader.command_table = cmd_table
 
         parser = CLICommandParser()
-        parser.load_command_table(cmd_table)
+        parser.load_command_table(self.mock_ctx.commands_loader)
         args = parser.parse_args('command the-name'.split())
         self.assertIs(args.func, command)
 
@@ -50,9 +51,10 @@ class TestParser(unittest.TestCase):
         command = CLICommand(self.mock_ctx, 'test command', test_handler)
         command.add_argument('req', '--req', required=True)
         cmd_table = {'test command': command}
+        self.mock_ctx.commands_loader.command_table = cmd_table
 
         parser = CLICommandParser()
-        parser.load_command_table(cmd_table)
+        parser.load_command_table(self.mock_ctx.commands_loader)
 
         args = parser.parse_args('test command --req yep'.split())
         self.assertIs(args.func, command)
@@ -68,9 +70,10 @@ class TestParser(unittest.TestCase):
         command = CLICommand(self.mock_ctx, 'test command', test_handler)
         command.add_argument('req', '--req', required=True, nargs=2)
         cmd_table = {'test command': command}
+        self.mock_ctx.commands_loader.command_table = cmd_table
 
         parser = CLICommandParser()
-        parser.load_command_table(cmd_table)
+        parser.load_command_table(self.mock_ctx.commands_loader)
 
         args = parser.parse_args('test command --req yep nope'.split())
         self.assertIs(args.func, command)
@@ -94,9 +97,10 @@ class TestParser(unittest.TestCase):
         command = CLICommand(self.mock_ctx, 'test command', test_handler)
         command.add_argument('opt', '--opt', required=True, **enum_choice_list(TestEnum))
         cmd_table = {'test command': command}
+        self.mock_ctx.commands_loader.command_table = cmd_table
 
         parser = CLICommandParser()
-        parser.load_command_table(cmd_table)
+        parser.load_command_table(self.mock_ctx.commands_loader)
 
         args = parser.parse_args('test command --opt alL_cAps'.split())
         self.assertEqual(args.opt, 'ALL_CAPS')
@@ -124,8 +128,9 @@ class TestParser(unittest.TestCase):
         command = CLICommand(self.mock_ctx, 'test command', test_handler)
         command.add_argument('req', '--req', required=True, mycustomarg=True)
         cmd_table = {'test command': command}
+        self.mock_ctx.commands_loader.command_table = cmd_table
         parser = CLICommandParser()
-        parser.load_command_table(cmd_table)
+        parser.load_command_table(self.mock_ctx.commands_loader)
 
 
 class VerifyError(object):  # pylint: disable=too-few-public-methods

--- a/tests/util.py
+++ b/tests/util.py
@@ -17,6 +17,9 @@ class MockContext(CLI):
 
 class TestCLI(CLI):
 
+    def get_cli_version(self):
+        return '0.1.0'
+
     def __init__(self, **kwargs):
         kwargs['config_dir'] = tempfile.mkdtemp()
         super(TestCLI, self).__init__(**kwargs)

--- a/tests/util.py
+++ b/tests/util.py
@@ -5,9 +5,11 @@
 
 import tempfile
 
-from knack.cli import CLI
+from knack.cli import CLI, CLICommandsLoader
 
 class MockContext(CLI):
 
     def __init__(self):
         super(MockContext, self).__init__(config_dir=tempfile.mkdtemp())
+        loader = CLICommandsLoader(self)
+        setattr(self, 'commands_loader', loader)

--- a/tests/util.py
+++ b/tests/util.py
@@ -13,3 +13,10 @@ class MockContext(CLI):
         super(MockContext, self).__init__(config_dir=tempfile.mkdtemp())
         loader = CLICommandsLoader(self)
         setattr(self, 'commands_loader', loader)
+
+
+class TestCLI(CLI):
+
+    def __init__(self, **kwargs):
+        kwargs['config_dir'] = tempfile.mkdtemp()
+        super(TestCLI, self).__init__(**kwargs)


### PR DESCRIPTION
Fixes #53. Closes #79.

Allows user to supply different help classes than the default when creating a CLIHelp object.

Adds support for command, command group, argument, and argument option deprecation.

Improves support for Unicode characters when displaying help. This will likely require the following magic comment as the first line of the help file:

```Python
# coding=utf-8
```

See: https://github.com/Azure/azure-cli/issues/5954
