### PR TITLE
Deprecation-related fixes

### DIFF
--- a/knack/arguments.py
+++ b/knack/arguments.py
@@ -235,7 +235,9 @@ class ArgumentsContext(object):
         :param kwargs: Possible values: `options_list`, `validator`, `completer`, `nargs`, `action`, `const`, `default`,
                        `type`, `choices`, `required`, `help`, `metavar`. See /docs/arguments.md.
         """
-        kwargs['action'] = self._handle_deprecations(argument_dest, **kwargs)
+        deprecate_action = self._handle_deprecations(argument_dest, **kwargs)
+        if deprecate_action:
+            kwargs['action'] = deprecate_action
         self.command_loader.argument_registry.register_cli_argument(self.command_scope,
                                                                     argument_dest,
                                                                     arg_type,
@@ -259,7 +261,9 @@ class ArgumentsContext(object):
         :param kwargs: Possible values: `options_list`, `validator`, `completer`, `nargs`, `action`, `const`, `default`,
                        `type`, `choices`, `required`, `help`, `metavar`. See /docs/arguments.md.
         """
-        kwargs['action'] = self._handle_deprecations(argument_dest, **kwargs)
+        deprecate_action = self._handle_deprecations(argument_dest, **kwargs)
+        if deprecate_action:
+            kwargs['action'] = deprecate_action
         self.command_loader.extra_argument_registry[self.command_scope][argument_dest] = CLICommandArgument(
             argument_dest, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = '0.4.0'
+VERSION = '0.4.1'
 
 DEPENDENCIES = [
     'argcomplete',


### PR DESCRIPTION
Fixes issues at the Knack level identified while supporting deprecation in CLI 2.0.

- Ensures that the `action` kwarg is only set if the item is deprecated. Previously it would set it to "None" which would then override a pre-existing action like `store_true`. This change ensures that doesn't happen.
- The command group table would only be filled by calls to create CommandGroup classes. This resulted in some gaps in the command group table. This ensures there are no gaps in the table. 