### PR TITLE
tab output: disable number parse

### DIFF
--- a/knack/output.py
+++ b/knack/output.py
@@ -187,7 +187,8 @@ class _TableOutput(object):  # pylint: disable=too-few-public-methods
     def dump(self, data):
         from tabulate import tabulate
         table_data = self._auto_table(data)
-        table_str = tabulate(table_data, headers="keys", tablefmt="simple") if table_data else ''
+        table_str = tabulate(table_data, headers="keys", tablefmt="simple",
+                             disable_numparse=True) if table_data else ''
         if table_str == '\n':
             raise ValueError('Unable to extract fields for table.')
         return table_str + '\n'

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -86,9 +86,9 @@ class TestOutput(unittest.TestCase):
         obj['lun'] = 0
         output_producer.out(CommandResultItem(obj), formatter=format_table, out_file=self.io)
         self.assertEqual(normalize_newlines(self.io.getvalue()), normalize_newlines(
-            """Active      Lun  Val
+            """Active    Lun    Val
 --------  -----  --------
-True          0  0b1f6472
+True      0      0b1f6472
 """))
 
     def test_out_table_list_of_lists(self):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -163,16 +163,12 @@ qwerty  0b1f6472qwerty  True
     def test_out_table_with_number(self):
         output_producer = OutputProducer(cli_ctx=self.mock_ctx)
         obj = OrderedDict()
-        obj['offer'] = 'RHEL'
-        obj['Publisher'] = 'RedHat'
         obj['Sku'] = '6.10'
-        obj['Urn'] = 'RedHat:RHEL:6.10:6.10.2018071006'
-        obj['Version'] = '6.10.2018071006'
         output_producer.out(CommandResultItem(obj), formatter=format_table, out_file=self.io)
         self.assertEqual(normalize_newlines(self.io.getvalue()), normalize_newlines(
-            """Publisher    Sku    Urn                               Version          Offer
------------  -----  --------------------------------  ---------------  -------
-RedHat       6.10   RedHat:RHEL:6.10:6.10.2018071006  6.10.2018071006  RHEL
+            """Sku
+-----
+6.10
 """))
 
     # TSV output tests

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -160,6 +160,21 @@ qwerty  0b1f6472qwerty  True      0b1f6472
 qwerty  0b1f6472qwerty  True
 """))
 
+    def test_out_table_with_number(self):
+        output_producer = OutputProducer(cli_ctx=self.mock_ctx)
+        obj = OrderedDict()
+        obj['offer'] = 'RHEL'
+        obj['Publisher'] = 'RedHat'
+        obj['Sku'] = '6.10'
+        obj['Urn'] = 'RedHat:RHEL:6.10:6.10.2018071006'
+        obj['Version'] = '6.10.2018071006'
+        output_producer.out(CommandResultItem(obj), formatter=format_table, out_file=self.io)
+        self.assertEqual(normalize_newlines(self.io.getvalue()), normalize_newlines(
+            """Publisher    Sku    Urn                               Version          Offer
+-----------  -----  --------------------------------  ---------------  -------
+RedHat       6.10   RedHat:RHEL:6.10:6.10.2018071006  6.10.2018071006  RHEL
+"""))
+
     # TSV output tests
     def test_output_format_dict(self):
         obj = {}


### PR DESCRIPTION
See https://github.com/Azure/azure-cli/issues/6878
By default, we should not let tabulate auto-parse number inside a string which would become confusing for being unpredictable. If we receive user voices for auto-parse(very unlikely), we can find a way for applications to opt in.