### PR TITLE
update README docs & examples link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,13 +73,13 @@ Usage
     sys.exit(exit_code)
 
 
-More samples and snippets available at `examples <examples>`__.
+More samples and snippets available at `examples <https://github.com/Microsoft/knack/tree/master/examples>`__.
 
 
 Documentation
 =============
 
-Documentation is available at `docs <docs>`__.
+Documentation is available at `docs <https://github.com/Microsoft/knack/tree/master/docs>`__.
 
 Developer Setup
 ===============


### PR DESCRIPTION
The links on pypi can't recognize the reroute to the docs/examples folder in this repo: https://pypi.org/project/knack/

Fixes https://github.com/Microsoft/knack/issues/92