### PR TITLE
Add Python3.7 support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,9 @@
 # R0913 Too many arguments
 # R0903 too-few-public-methods
 # R0401 cyclic-import
-disable=W0511,C0111,C0103,I0011,R0913,R0903,R0401
+# R0205 useless-object-inheritance
+# R1717 consider-using-dict-comprehension
+disable=W0511,C0111,C0103,I0011,R0913,R0903,R0401,R0205,R1717
 
 # note: This is useful but some pylint suppressions only apply to Python 2 or 3
 # and we run pylint on both Python 2 and 3. e.g. You may see some no-member useless-suppression messages.

--- a/knack/arguments.py
+++ b/knack/arguments.py
@@ -40,7 +40,7 @@ class CLIArgumentType(object):
         self.settings.update(**kwargs)
 
 
-class CLICommandArgument(object):  # pylint: disable=too-few-public-methods
+class CLICommandArgument(object):
 
     NAMED_ARGUMENTS = ['options_list', 'validator', 'completer', 'arg_group', 'deprecate_info']
 
@@ -69,16 +69,16 @@ class CLICommandArgument(object):  # pylint: disable=too-few-public-methods
     def __getattr__(self, name):
         if name in self.NAMED_ARGUMENTS:
             return self.type.settings.get(name, None)
-        elif name == 'name':
+        if name == 'name':
             return self.type.settings.get('dest', None)
-        elif name == 'options':
+        if name == 'options':
             return {key: value for key, value in self.type.settings.items()
                     if key != 'options' and key not in self.NAMED_ARGUMENTS and
                     not value == CLIArgumentType.REMOVE}
-        elif name == 'choices':
+        if name == 'choices':
             return self.type.settings.get(name, None)
-        else:
-            raise AttributeError(name)
+
+        raise AttributeError(name)
 
     def __setattr__(self, name, value):  # pylint: disable=inconsistent-return-statements
         if name == 'type':

--- a/knack/help.py
+++ b/knack/help.py
@@ -476,7 +476,7 @@ class CLIHelp(object):
             _print_indent(u'{0}'.format(e.text), indent)
             print('')
 
-    def _print_arguments(self, help_file):
+    def _print_arguments(self, help_file):  # pylint: disable=too-many-statements
 
         LINE_FORMAT = u'{name}{padding}{tags}{separator}{short_summary}'
         indent = 1

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -59,12 +59,12 @@ class CLICommandParser(argparse.ArgumentParser):
                     item = option
                 scrubbed_options_list.append(item)
             return obj.add_argument(*scrubbed_options_list, **argparse_options)
-        else:
-            if 'required' in argparse_options:
-                del argparse_options['required']
-            if 'metavar' not in argparse_options:
-                argparse_options['metavar'] = '<{}>'.format(argparse_options['dest'].upper())
-            return obj.add_argument(**argparse_options)
+
+        if 'required' in argparse_options:
+            del argparse_options['required']
+        if 'metavar' not in argparse_options:
+            argparse_options['metavar'] = '<{}>'.format(argparse_options['dest'].upper())
+        return obj.add_argument(**argparse_options)
 
     def __init__(self, cli_ctx=None, cli_help=None, **kwargs):
         """ Create the argument parser

--- a/knack/util.py
+++ b/knack/util.py
@@ -65,17 +65,17 @@ def todict(obj, post_processor=None):  # pylint: disable=too-many-return-stateme
     if isinstance(obj, dict):
         result = {k: todict(v, post_processor) for (k, v) in obj.items()}
         return post_processor(obj, result) if post_processor else result
-    elif isinstance(obj, list):
+    if isinstance(obj, list):
         return [todict(a, post_processor) for a in obj]
-    elif isinstance(obj, Enum):
+    if isinstance(obj, Enum):
         return obj.value
-    elif isinstance(obj, (date, time, datetime)):
+    if isinstance(obj, (date, time, datetime)):
         return obj.isoformat()
-    elif isinstance(obj, timedelta):
+    if isinstance(obj, timedelta):
         return str(obj)
-    elif hasattr(obj, '_asdict'):
+    if hasattr(obj, '_asdict'):
         return todict(obj._asdict(), post_processor)
-    elif hasattr(obj, '__dict__'):
+    if hasattr(obj, '__dict__'):
         result = {to_camel_case(k): todict(v, post_processor)
                   for k, v in obj.__dict__.items()
                   if not callable(v) and not k.startswith('_')}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ colorama==0.3.9
 flake8==3.2.1
 jmespath==0.9.2
 mock==2.0.0
-pylint==2.1.1
+pylint==1.8.4; python_version <= '2.7'
+pylint==2.1.1; python_version >= '3.5'
 pygments==2.2.0
 pyyaml==3.12
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama==0.3.9
 flake8==3.2.1
 jmespath==0.9.2
 mock==2.0.0
-pylint==1.8.4
+pylint==2.1.1
 pygments==2.2.0
 pyyaml==3.12
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
     ],
     packages=['knack', 'knack.testsdk'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py27,py35,py36,py37
 [testenv]
 deps = -rrequirements.txt
 commands=


### PR DESCRIPTION
To add python3.7 to tox check I had to upgrade pylint.
Doing so brought new checks

Added R0205 and R1717 to disable list because they're related to features only available on python3.7

Applied R1705: Unnecessary "else" after "return" (no-else-return) as needed.