### PR TITLE
Keep logging verbosity and output format on namespace.

### DIFF
--- a/knack/log.py
+++ b/knack/log.py
@@ -8,7 +8,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 
 from .util import CtxTypeError, ensure_dir
-from .events import EVENT_INVOKER_PRE_CMD_TBL_CREATE, EVENT_PARSER_GLOBAL_CREATE
+from .events import EVENT_PARSER_GLOBAL_CREATE
 
 CLI_LOGGER_NAME = 'cli'
 
@@ -98,18 +98,6 @@ class CLILogging(object):
         arg_group.add_argument(CLILogging.DEBUG_FLAG, dest='_log_verbosity_debug', action='store_true',
                                help='Increase logging verbosity to show all debug logs.')
 
-    @staticmethod
-    def remove_logger_flags(_, **kwargs):
-        args = kwargs.get('args')
-        try:
-            args.remove(CLILogging.VERBOSE_FLAG)
-        except ValueError:
-            pass
-        try:
-            args.remove(CLILogging.DEBUG_FLAG)
-        except ValueError:
-            pass
-
     def __init__(self, name, cli_ctx=None):
         """
 
@@ -128,7 +116,6 @@ class CLILogging(object):
         self.console_log_format = CLILogging._get_console_log_format()
         self.cli_ctx = cli_ctx
         self.cli_ctx.register_event(EVENT_PARSER_GLOBAL_CREATE, CLILogging.on_global_arguments)
-        self.cli_ctx.register_event(EVENT_INVOKER_PRE_CMD_TBL_CREATE, CLILogging.remove_logger_flags)
 
     def configure(self, args):
         """ Configure the loggers with the appropriate log level etc.

--- a/knack/output.py
+++ b/knack/output.py
@@ -96,8 +96,6 @@ class OutputProducer(object):
         args = kwargs.get('args')
         # Set the output type for this invocation
         cli_ctx.invocation.data['output'] = getattr(args, OutputProducer.ARG_DEST)
-        # We've handled the argument so remove it
-        delattr(args, OutputProducer.ARG_DEST)
 
     def __init__(self, cli_ctx=None):
         """ Manages the production of output from the result of a command invocation

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = '0.4.4'
+VERSION = '0.4.5'
 
 DEPENDENCIES = [
     'argcomplete',

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -30,12 +30,6 @@ class TestLoggingEventHandling(unittest.TestCase):
         parser_arg_group_mock.add_argument.assert_any_call(CLILogging.DEBUG_FLAG, dest=mock.ANY, action=mock.ANY,
                                                            help=mock.ANY)
 
-    def test_logging_arguments_removed(self):
-        arguments = [CLILogging.VERBOSE_FLAG, CLILogging.DEBUG_FLAG]
-        self.mock_ctx.raise_event(EVENT_INVOKER_PRE_CMD_TBL_CREATE, args=arguments)
-        # After the event is raised, the arguments should have been removed
-        self.assertFalse(arguments)
-
 
 class TestLoggingLevel(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Allows you to access the output format on the namespace through `_output_format` and logging levels through `_logging_verbosity_verbose` and `_logging_verbosity_debug`. These were previously suppressed. 