### PR TITLE
Update prompting with a more complete message

### DIFF
--- a/knack/prompting.py
+++ b/knack/prompting.py
@@ -115,7 +115,7 @@ def prompt_choice_list(msg, a_list, default=1, help_string=None):
                          for i, x in enumerate(a_list)])
     allowed_vals = list(range(1, len(a_list) + 1))
     while True:
-        val = _input('{}\n{}\nPlease enter a choice [{}]: '.format(msg, options, default))
+        val = _input('{}\n{}\nPlease enter a choice [Default choice({})]: '.format(msg, options, default))
         if val == '?' and help_string is not None:
             print(help_string)
             continue


### PR DESCRIPTION
"Please enter a choice [1]:" is not so clear. 

Making the prompt as "Please enter a choice [Default choice (1)]:" so a complete message is conveyed.