### PR TITLE
Correct location of config directory

### DIFF
--- a/knack/cli.py
+++ b/knack/cli.py
@@ -81,7 +81,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
         self._event_handlers = defaultdict(lambda: [])
         # Data that's typically backed to persistent storage
         self.config = config_cls(
-            config_dir=config_dir or os.path.join('~', '.{}'.format(cli_name)),
+            config_dir=config_dir or os.path.expanduser(os.path.join('~', '.{}'.format(cli_name))),
             config_env_var_prefix=config_env_var_prefix or cli_name.upper()
         )
         # In memory collection of key-value data for this current cli. This persists between invocations.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = '0.5.3'
+VERSION = '0.5.4'
 
 DEPENDENCIES = [
     'argcomplete',


### PR DESCRIPTION
Updated to create the config directory in the current user’s home directory instead of the current working directory.