### PR TITLE
Support for expanding prefixed-files as string arguments

### DIFF
--- a/knack/parser.py
+++ b/knack/parser.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 import argparse
-import os
 
 from .deprecation import Deprecated
 from .events import EVENT_PARSER_GLOBAL_CREATE
@@ -76,16 +75,16 @@ class CLICommandParser(argparse.ArgumentParser):
         :param args: Arguments passed from command line
         :type args: list
         """
-        for arg in range(len(args)):
+        for arg, _ in enumerate(args):
             if args[arg].startswith('@'):
                 try:
-                    logger.debug('Attempting to read file {}'.format(args[arg][1:]))
+                    logger.debug('Attempting to read file %s', args[arg][1:])
                     with open(args[arg][1:], 'r') as f:
                         content = f.read()
                     args[arg] = content
-                except FileNotFoundError:
+                except IOError:
                     # Leave arg unmodified
-                    logger.debug('File Error: Failed to open {}, assume not a file'.format(args[arg][1:]))
+                    logger.debug('File Error: Failed to open %s, assume not a file', args[arg][1:])
         return args
 
     def __init__(self, cli_ctx=None, cli_help=None, **kwargs):

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -4,11 +4,14 @@
 # --------------------------------------------------------------------------------------------
 
 import argparse
+import os
 
 from .deprecation import Deprecated
 from .events import EVENT_PARSER_GLOBAL_CREATE
+from .log import get_logger
 from .util import CtxTypeError
 
+logger = get_logger(__name__)
 
 # List of keyword arguments supported in argparse
 # from https://github.com/python/cpython/blob/master/Lib/argparse.py#L748
@@ -65,6 +68,25 @@ class CLICommandParser(argparse.ArgumentParser):
         if 'metavar' not in argparse_options:
             argparse_options['metavar'] = '<{}>'.format(argparse_options['dest'].upper())
         return obj.add_argument(**argparse_options)
+
+    @staticmethod
+    def _expand_prefixed_files(args):
+        """ Load arguments prefixed with '@' from file as string
+
+        :param args: Arguments passed from command line
+        :type args: list
+        """
+        for arg in range(len(args)):
+            if args[arg].startswith('@'):
+                try:
+                    logger.debug('Attempting to read file {}'.format(args[arg][1:]))
+                    with open(args[arg][1:], 'r') as f:
+                        content = f.read()
+                    args[arg] = content
+                except FileNotFoundError:
+                    # Leave arg unmodified
+                    logger.debug('File Error: Failed to open {}, assume not a file'.format(args[arg][1:]))
+        return args
 
     def __init__(self, cli_ctx=None, cli_help=None, **kwargs):
         """ Create the argument parser
@@ -224,3 +246,12 @@ class CLICommandParser(argparse.ArgumentParser):
                                 self._actions[-1] if is_group else self,
                                 is_group)
         self.exit()
+
+    def parse_args(self, args=None, namespace=None):
+        """ Overrides argparse.ArgumentParser.parse_args
+
+        Enables '@'-prefixed files to be expanded before arguments are processed
+        by ArgumentParser.parse_args as usual
+        """
+        self._expand_prefixed_files(args)
+        return super(CLICommandParser, self).parse_args(args)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -133,6 +133,34 @@ class TestParser(unittest.TestCase):
         parser = CLICommandParser()
         parser.load_command_table(self.mock_ctx.commands_loader)
 
+    def test_prefix_file_expansion(self):
+        import json, os
+
+        def test_handler():
+            pass
+
+        def create_test_file(file, contents):
+            with open(file, 'w') as f:
+                f.write(contents)
+
+        def remove_test_file(file):
+            os.remove(file)
+
+        json_test_data = json.dumps({'one': 1, 'two': 2, 'three': 3})
+        create_test_file('test.json', json_test_data)
+
+        command = CLICommand(self.mock_ctx, 'test command', test_handler)
+        command.add_argument('json_data', '--param')
+        cmd_table = {'test command': command}
+        self.mock_ctx.commands_loader.command_table = cmd_table
+        parser = CLICommandParser()
+        parser.load_command_table(self.mock_ctx.commands_loader)
+
+        args = parser.parse_args('test command --param @test.json'.split())
+        self.assertEqual(json_test_data, args.json_data)
+
+        remove_test_file('test.json')
+
 
 class VerifyError(object):  # pylint: disable=too-few-public-methods
 


### PR DESCRIPTION
This PR is in reference to Issue #81 

Hello, here is an overview of the submitted changes.

All arguments passed to `CLICommandParser.parse_args()` will be checked for a '`@`' prefix, which will indicate a path to a file. If the file is successfully opened, the prefixed arguments are replaced with the referenced file's contents, before being handed off to `parse_args()` for processing as usual. If the file fails to open, the prefixed argument is handed off unmodified,  with the failure noted in the debugging log.

In addition, a new test, `test_prefix_file_expansion`, was added to `test_parser.py`.  All tests pass.