### PR TITLE
Include tests and license in sdist pypi tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include *.rst
+include LICENSE
+recursive-include tests *


### PR DESCRIPTION
This allows distributors to validate their python stack can basically run knack.