### PR TITLE
Command suggestion feature from CLI 2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Release History
 +++++
 * Adds ability to declare that command groups, commands, and arguments are in a preview status and therefore might change or be removed. This is done by passing the kwarg `is_preview=True`.
 * Adds a generic `TagDecorator` class to `knack.util` that allows you to create your own colorized tags like `[Preview]` and `[Deprecated]`.
+* When an incorrect command name is entered, Knack will now attempt to suggest the closest alternative.
 
 0.6.1
 +++++

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+
 import argparse
 
 from .deprecation import Deprecated

--- a/tests/test_cli_scenarios.py
+++ b/tests/test_cli_scenarios.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import os
+from collections import OrderedDict
 import unittest
 try:
     import mock
@@ -11,7 +12,6 @@ except ImportError:
     from unittest import mock
 import mock
 
-from collections import OrderedDict
 from six import StringIO
 
 from knack import CLI

--- a/tests/test_command_with_configured_defaults.py
+++ b/tests/test_command_with_configured_defaults.py
@@ -5,17 +5,15 @@
 from __future__ import print_function
 import os
 import logging
+import sys
 import unittest
 try:
     import mock
 except ImportError:
     from unittest import mock
-from six import StringIO
-import sys
 
 from knack.arguments import ArgumentsContext
-from knack.commands import CLICommandsLoader, CLICommand, CommandGroup
-from knack.config import CLIConfig
+from knack.commands import CLICommandsLoader, CommandGroup
 from tests.util import DummyCLI, redirect_io
 
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -133,7 +133,8 @@ Arguments
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('cmd5 -h'.split())
         actual = self.io.getvalue()
-        self.assertTrue(u"'cmd5' is not in the" in actual)
+        expected = """The most similar choices to 'cmd5'"""
+        self.assertIn(expected, actual)
 
 
 class TestCommandGroupDeprecation(unittest.TestCase):
@@ -232,7 +233,8 @@ Group
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('group5 -h'.split())
         actual = self.io.getvalue()
-        self.assertTrue(u"'group5' is not in the" in actual)
+        expected = """The most similar choices to 'group5'"""
+        self.assertIn(expected, actual)
 
     @redirect_io
     def test_deprecate_command_implicitly(self):

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -28,6 +28,7 @@ def example_arg_handler(arg1, opt1, arg2=None, opt2=None, arg3=None,
     pass
 
 
+# pylint: disable=line-too-long
 class TestCommandDeprecation(unittest.TestCase):
 
     def setUp(self):
@@ -132,7 +133,7 @@ Arguments
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('cmd5 -h'.split())
         actual = self.io.getvalue()
-        self.assertTrue(u'invalid choice' in actual and u'cmd5' in actual)
+        self.assertTrue(u"'cmd5' is not in the" in actual)
 
 
 class TestCommandGroupDeprecation(unittest.TestCase):
@@ -231,7 +232,7 @@ Group
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('group5 -h'.split())
         actual = self.io.getvalue()
-        self.assertTrue(u'invalid choice' in actual and u'group5' in actual)
+        self.assertTrue(u"'group5' is not in the" in actual)
 
     @redirect_io
     def test_deprecate_command_implicitly(self):

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -3,12 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import os
-import stat
 import unittest
-import tempfile
-import mock
-from six.moves import configparser
 
 from knack.introspection import extract_full_summary_from_signature, option_descriptions, extract_args_from_signature
 


### PR DESCRIPTION
Closes #131. Add the feature from Azure CLI where the CLI will try to suggest the closest alternative when the user mistypes a command.