### PR TITLE
Fix red color contrast for error messages

### DIFF
--- a/knack/log.py
+++ b/knack/log.py
@@ -45,8 +45,8 @@ class _CustomStreamHandler(logging.StreamHandler):
                 return wrap_msg_with_color
 
             cls.COLOR_MAP = {
-                logging.CRITICAL: _color_wrapper(colorama.Fore.RED),
-                logging.ERROR: _color_wrapper(colorama.Fore.RED),
+                logging.CRITICAL: _color_wrapper(colorama.Fore.LIGHTRED_EX),
+                logging.ERROR: _color_wrapper(colorama.Fore.LIGHTRED_EX),
                 logging.WARNING: _color_wrapper(colorama.Fore.YELLOW),
                 logging.INFO: _color_wrapper(colorama.Fore.GREEN),
                 logging.DEBUG: _color_wrapper(colorama.Fore.CYAN)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -85,7 +85,7 @@ class TestLoggingLevel(unittest.TestCase):
 
 
 class TestCustomStreamHandler(unittest.TestCase):
-    expectation = {logging.CRITICAL: colorama.Fore.RED, logging.ERROR: colorama.Fore.RED,
+    expectation = {logging.CRITICAL: colorama.Fore.LIGHTRED_EX, logging.ERROR: colorama.Fore.LIGHTRED_EX,
                    logging.WARNING: colorama.Fore.YELLOW, logging.INFO: colorama.Fore.GREEN,
                    logging.DEBUG: colorama.Fore.CYAN}
 


### PR DESCRIPTION
The current red color is not contrasting enough in command prompt and powershell console.

New Red on top older one is below for comparison.

![image](https://user-images.githubusercontent.com/11888714/56231520-49c01300-609c-11e9-8844-6f6d2e39c3d1.png)

Resolves issue #71 