### PR TITLE
Command/Argument Preview Mechanism

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -99,7 +99,6 @@ Release History
 0.1.1
 +++++
 * Add more types of command and argument loaders.
-* Add tests.
 
 0.1.0
 +++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Release History
 0.6.2
 +++++
 * Adds ability to declare that command groups, commands, and arguments are in a preview status and therefore might change or be removed. This is done by passing the kwarg `is_preview=True`.
+* Adds a generic `TagDecorator` class to `knack.util` that allows you to create your own colorized tags like `[Preview]` and `[Deprecated]`.
 
 0.6.1
 +++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,0 +1,105 @@
+.. :changelog:
+
+Release History
+===============
+
+0.6.2
++++++
+* Adds ability to declare that command groups, commands, and arguments are in a preview status and therefore might change or be removed. This is done by passing the kwarg `is_preview=True`.
+
+0.6.1
++++++
+* Always read from local for configured_default
+
+0.6.0
++++++
+* Support local context chained config file
+
+0.5.4
++++++
+* Allows the loading of text files using @filename syntax.
+* Adds the argument kwarg configured_default to support setting argument defaults via the config file's [defaults] section or an environment variable.
+
+0.5.3
++++++
+* Removes an incorrect check when adding arguments.
+
+0.5.2
++++++
+* Updates usages of yaml.load to use yaml.safe_load.
+
+0.5.1
++++++
+* Fix issue with some scenarios (no args and --version)
+
+0.5.0
++++++
+* Adds support for positional arguments with the .positional helper method on ArgumentsContext.
+* Removes the necessity for the type field in help.py. This information can be inferred from the class, so specifying it causes unnecessary crashes.
+* Adds support for examining the result of a command after a call to invoke. The raw object, error (if any) an exit code are accessible.
+* Adds support for accessing the command instance from inside custom commands by putting the special argument cmd in the signature.
+* Fixes an issue with the default config directory. It use to be .cli and is now based on the CLI name.
+* Fixes regression in knack 0.4.5 in behavior when cli_name --verbose/debug is used. Displays the welcome message as intended.
+* Adds ability to specify line width for help text display.
+
+0.4.5
++++++
+* Preserves logging verbosity and output format on the namespace for use by validators.
+
+0.4.4
++++++
+* Adds ability to set config file name.
+* Fixes bug with argument deprecations.
+
+0.4.3
++++++
+* Fixes issue where values were sometimes ignored when using deprecated options regardless of which option was given.
+
+0.4.2
++++++
+* Bug fix: disable number parse on table mode PR #88
+
+0.4.1
++++++
+* Fixes bug with deprecation mechanism.
+* Fixes an issue where the command group table would only be filled by calls to create CommandGroup classes. This resulted in some gaps in the command group table.
+
+0.4.0
++++++
+* Add mechanism to deprecate commands, command groups, arguments and argument options.
+* Improve help display support for Unicode.
+
+0.3.3
++++++
+* expose a callback to let client side perform extra logics (#80)
+* output: don't skip false value on auto-tabulating (#83)
+
+0.3.2
++++++
+* ArgumentsContext.ignore() should use hidden options_list (#76)
+* Consolidate exception handling (#66)
+
+0.3.1
++++++
+* Performance optimization - Delay import of platform and colorama (#47)
+* CLIError: Inherit from Exception directly (#65)
+* Explicitly state which packages to include (so exclude 'tests') (#68)
+
+0.2.0
++++++
+* Support command level and argument level validators.
+* knack.commands.CLICommandsLoader now accepts a command_cls argument so you can provide your own CLICommand class.
+* logging: make determine_verbose_level private method.
+* Allow overriding of NAMED_ARGUMENTS
+* Only pass valid argparse kwargs to argparse.ArgumentParser.add_argument and ignore the rest
+* logging: make determine_verbose_level private method
+* Remove cli_command, register_cli_argument, register_extra_cli_argument as ways to register commands and arguments.
+
+0.1.1
++++++
+* Add more types of command and argument loaders.
+* Add tests.
+
+0.1.0
++++++
+* Initial release

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -277,10 +277,6 @@ class CLICommandsLoader(object):
         kwargs['object_type'] = 'command group'
         return Deprecated(self.cli_ctx, **kwargs)
 
-    def preview(self, **kwargs):
-        kwargs['object_type'] = 'command group'
-        return PreviewItem(self.cli_ctx, **kwargs)
-
 
 class CommandGroup(object):
 
@@ -304,6 +300,11 @@ class CommandGroup(object):
         Deprecated.ensure_new_style_deprecation(self.command_loader.cli_ctx, self.group_kwargs, 'command group')
         if kwargs['deprecate_info']:
             kwargs['deprecate_info'].target = group_name
+        if kwargs.get('is_preview', False):
+            kwargs['preview_info'] = PreviewItem(
+                target=group_name,
+                object_type='command group'
+            )
         command_loader._populate_command_group_table_with_subgroups(group_name)  # pylint: disable=protected-access
         self.command_loader.command_group_table[group_name] = self
 
@@ -322,7 +323,8 @@ class CommandGroup(object):
         :type handler_name: str
         :param kwargs: Kwargs to apply to the command.
                        Possible values: `client_factory`, `arguments_loader`, `description_loader`, `description`,
-                       `formatter_class`, `table_transformer`, `deprecate_info`, `validator`, `confirmation`.
+                       `formatter_class`, `table_transformer`, `deprecate_info`, `validator`, `confirmation`,
+                       `is_preview`.
         """
         import copy
 
@@ -331,7 +333,11 @@ class CommandGroup(object):
         command_kwargs.update(kwargs)
         # don't inherit deprecation info from command group
         command_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
-        command_kwargs['preview_info'] = kwargs.get('preview_info', None)
+        if kwargs.get('is_preview', False):
+            command_kwargs['preview_info'] = PreviewItem(
+                self.command_loader.cli_ctx,
+                object_type='command'
+            )
 
         self.command_loader._populate_command_group_table_with_subgroups(' '.join(command_name.split()[:-1]))  # pylint: disable=protected-access
         self.command_loader.command_table[command_name] = self.command_loader.create_command(
@@ -342,7 +348,3 @@ class CommandGroup(object):
     def deprecate(self, **kwargs):
         kwargs['object_type'] = 'command'
         return Deprecated(self.command_loader.cli_ctx, **kwargs)
-
-    def preview(self, **kwargs):
-        kwargs['object_type'] = 'command'
-        return PreviewItem(self.command_loader.cli_ctx, **kwargs)

--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -5,6 +5,7 @@
 
 from six import string_types as STRING_TYPES
 
+from .util import ColorizedString
 
 DEFAULT_DEPRECATED_TAG = '[Deprecated]'
 
@@ -27,23 +28,6 @@ def resolve_deprecate_info(cli_ctx, name):
         if group_kwargs:
             deprecate_info = group_kwargs.get('deprecate_info', None)
     return deprecate_info
-
-
-class ColorizedString(object):
-
-    def __init__(self, message, color):
-        import colorama
-        self._message = message
-        self._color = getattr(colorama.Fore, color.upper(), None)
-
-    def __len__(self):
-        return len(self._message)
-
-    def __str__(self):
-        import colorama
-        if not self._color:
-            return self._message
-        return self._color + self._message + colorama.Fore.RESET
 
 
 # pylint: disable=too-many-instance-attributes

--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -5,7 +5,7 @@
 
 from six import string_types as STRING_TYPES
 
-from .util import ColorizedString
+from .util import TagDecorator
 
 DEFAULT_DEPRECATED_TAG = '[Deprecated]'
 
@@ -31,7 +31,7 @@ def resolve_deprecate_info(cli_ctx, name):
 
 
 # pylint: disable=too-many-instance-attributes
-class Deprecated(object):
+class Deprecated(TagDecorator):
 
     @staticmethod
     def ensure_new_style_deprecation(cli_ctx, kwargs, object_type):
@@ -46,7 +46,7 @@ class Deprecated(object):
         return deprecate_info
 
     def __init__(self, cli_ctx=None, object_type='', target=None, redirect=None, hide=False, expiration=None,
-                 tag_func=None, message_func=None):
+                 tag_func=None, message_func=None, **kwargs):
         """ Create a collection of deprecation metadata.
 
         :param cli_ctx: The CLI context associated with the deprecated item.
@@ -71,13 +71,6 @@ class Deprecated(object):
                              Omit to use the default.
         :type message_func: callable
         """
-        self.cli_ctx = cli_ctx
-        self.object_type = object_type
-        self.target = target
-        self.redirect = redirect
-        self.hide = hide
-        self.expiration = expiration
-
         def _default_get_message(self):
             msg = "This {} has been deprecated and will be removed ".format(self.object_type)
             if self.expiration:
@@ -88,24 +81,18 @@ class Deprecated(object):
                 msg += " Use '{}' instead.".format(self.redirect)
             return msg
 
-        self._get_tag = tag_func or (lambda _: DEFAULT_DEPRECATED_TAG)
-        self._get_message = message_func or _default_get_message
+        self.redirect = redirect
+        self.hide = hide
+        self.expiration = expiration
 
-    def __deepcopy__(self, memo):
-        import copy
-
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-        for k, v in self.__dict__.items():
-            try:
-                setattr(result, k, copy.deepcopy(v, memo))
-            except TypeError:
-                if k == 'cli_ctx':
-                    setattr(result, k, self.cli_ctx)
-                else:
-                    raise
-        return result
+        super(Deprecated, self).__init__(
+            cli_ctx=cli_ctx,
+            object_type=object_type,
+            target=target,
+            color='yellow',
+            tag_func=tag_func or (lambda _: DEFAULT_DEPRECATED_TAG),
+            message_func=message_func or _default_get_message
+        )
 
     # pylint: disable=no-self-use
     def _version_less_than_or_equal_to(self, v1, v2):
@@ -131,16 +118,6 @@ class Deprecated(object):
 
     def show_in_help(self):
         return not self.hidden() and not self.expired()
-
-    @property
-    def tag(self):
-        """ Returns a tag object. """
-        return ColorizedString(self._get_tag(self), 'yellow')
-
-    @property
-    def message(self):
-        """ Returns a tuple with the formatted message string and the message length. """
-        return ColorizedString(self._get_message(self), 'yellow')
 
 
 class ImplicitDeprecated(Deprecated):

--- a/knack/help.py
+++ b/knack/help.py
@@ -176,7 +176,6 @@ class HelpFile(HelpObject):
             del preview_kwargs['_get_message']
             self.preview_info = ImplicitPreviewItem(**preview_kwargs)
 
-
     def load(self, options):
         description = getattr(options, 'description', None)
         try:

--- a/knack/help.py
+++ b/knack/help.py
@@ -10,6 +10,7 @@ import textwrap
 
 from .deprecation import ImplicitDeprecated, resolve_deprecate_info
 from .log import get_logger
+from .preview import ImplicitPreviewItem, resolve_preview_info
 from .util import CtxTypeError
 from .help_files import _load_help_file
 
@@ -19,13 +20,6 @@ logger = get_logger(__name__)
 
 FIRST_LINE_PREFIX = ' : '
 REQUIRED_TAG = '[Required]'
-
-
-def _get_preview_tag():
-    import colorama
-    PREVIEW_TAG = '{}[Preview]{}'.format(colorama.Fore.CYAN, colorama.Fore.RESET)
-    PREVIEW_TAG_LEN = len(PREVIEW_TAG) - 2 * len(colorama.Fore.RESET)
-    return (PREVIEW_TAG, PREVIEW_TAG_LEN)
 
 
 def _get_hanging_indent(max_length, indent):
@@ -159,6 +153,30 @@ class HelpFile(HelpObject):
             del deprecate_kwargs['_get_message']
             self.deprecate_info = ImplicitDeprecated(**deprecate_kwargs)
 
+        # resolve preview info
+        direct_preview_info = resolve_preview_info(help_ctx.cli_ctx, delimiters)
+        if direct_preview_info:
+            self.preview_info = direct_preview_info
+
+        # search for implicit preview
+        path_comps = delimiters.split()[:-1]
+        implicit_preview_info = None
+        while path_comps and not implicit_preview_info:
+            implicit_preview_info = resolve_preview_info(help_ctx.cli_ctx, ' '.join(path_comps))
+            del path_comps[-1]
+
+        if implicit_preview_info:
+            preview_kwargs = implicit_preview_info.__dict__.copy()
+            if delimiters in help_ctx.cli_ctx.invocation.commands_loader.command_table:
+                preview_kwargs['object_type'] = 'command'
+            else:
+                preview_kwargs['object_type'] = 'command group'
+
+            del preview_kwargs['_get_tag']
+            del preview_kwargs['_get_message']
+            self.preview_info = ImplicitPreviewItem(**preview_kwargs)
+
+
     def load(self, options):
         description = getattr(options, 'description', None)
         try:
@@ -208,7 +226,6 @@ class GroupHelpFile(HelpFile):
 
         super(GroupHelpFile, self).__init__(help_ctx, delimiters)
         self.type = 'group'
-        self.preview_info = getattr(parser, 'preview_info', None)
 
         self.children = []
         if getattr(parser, 'choices', None):
@@ -244,6 +261,7 @@ class CommandHelpFile(HelpFile):
                 param_kwargs = {
                     'name_source': [action.metavar or action.dest],
                     'deprecate_info': getattr(action, 'deprecate_info', None),
+                    'preview_info': getattr(action, 'preview_info', None),
                     'description': action.help,
                     'choices': action.choices,
                     'required': False,
@@ -280,7 +298,8 @@ class CommandHelpFile(HelpFile):
             self.parameters.append(HelpParameter(**param_kwargs))
         param_kwargs.update({
             'name_source': normal_options,
-            'deprecate_info': getattr(param, 'deprecate_info', None)
+            'deprecate_info': getattr(param, 'deprecate_info', None),
+            'preview_info': getattr(param, 'preview_info', None)
         })
         self.parameters.append(HelpParameter(**param_kwargs))
 
@@ -304,7 +323,7 @@ class CommandHelpFile(HelpFile):
 class HelpParameter(HelpObject):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, name_source, description, required, choices=None,
-                 default=None, group_name=None, deprecate_info=None):
+                 default=None, group_name=None, deprecate_info=None, preview_info=None):
         super(HelpParameter, self).__init__()
         self.name_source = name_source
         self.name = ' '.join(sorted(name_source))
@@ -317,6 +336,7 @@ class HelpParameter(HelpObject):  # pylint: disable=too-many-instance-attributes
         self.default = default
         self.group_name = group_name
         self.deprecate_info = deprecate_info
+        self.preview_info = preview_info
 
     def update_from_data(self, data):
         if self.name != data.get('name'):
@@ -367,6 +387,8 @@ class CLIHelp(object):
                 lines.append(item.long_summary)
             if item.deprecate_info:
                 lines.append(str(item.deprecate_info.message))
+            if item.preview_info:
+                lines.append(str(item.preview_info.message))
             return ' '.join(lines)
 
         indent += 1
@@ -381,15 +403,18 @@ class CLIHelp(object):
         self.max_line_len = 0
 
         def _build_tags_string(item):
-            PREVIEW_TAG, PREVIEW_TAG_LEN = _get_preview_tag()
+
+            preview_info = getattr(item, 'preview_info', None)
+            preview = preview_info.tag if preview_info else ''
+
             deprecate_info = getattr(item, 'deprecate_info', None)
             deprecated = deprecate_info.tag if deprecate_info else ''
-            preview = PREVIEW_TAG if getattr(item, 'preview_info', None) else ''
+
             required = REQUIRED_TAG if getattr(item, 'required', None) else ''
-            tags = ' '.join([x for x in [str(deprecated), preview, required] if x])
+            tags = ' '.join([x for x in [str(deprecated), str(preview), required] if x])
             tags_len = sum([
                 len(deprecated),
-                PREVIEW_TAG_LEN if preview else 0,
+                len(preview),
                 len(required),
                 tags.count(' ')
             ])
@@ -488,15 +513,18 @@ class CLIHelp(object):
             return None
 
         def _build_tags_string(item):
-            PREVIEW_TAG, PREVIEW_TAG_LEN = _get_preview_tag()
+
+            preview_info = getattr(item, 'preview_info', None)
+            preview = preview_info.tag if preview_info else ''
+
             deprecate_info = getattr(item, 'deprecate_info', None)
             deprecated = deprecate_info.tag if deprecate_info else ''
-            preview = PREVIEW_TAG if getattr(item, 'preview_info', None) else ''
+
             required = REQUIRED_TAG if getattr(item, 'required', None) else ''
-            tags = ' '.join([x for x in [str(deprecated), preview, required] if x])
+            tags = ' '.join([x for x in [str(deprecated), str(preview), required] if x])
             tags_len = sum([
                 len(deprecated),
-                PREVIEW_TAG_LEN if preview else 0,
+                len(preview),
                 len(required),
                 tags.count(' ')
             ])
@@ -573,6 +601,9 @@ class CLIHelp(object):
             deprecate_info = getattr(item, 'deprecate_info', None)
             if deprecate_info:
                 lines.append(str(item.deprecate_info.message))
+            preview_info = getattr(item, 'preview_info', None)
+            if preview_info:
+                lines.append(str(item.preview_info.message))
             return ' '.join(lines)
 
         group_registry = ArgumentGroupRegistry([p.group_name for p in help_file.parameters if p.group_name])

--- a/knack/help.py
+++ b/knack/help.py
@@ -171,9 +171,6 @@ class HelpFile(HelpObject):
                 preview_kwargs['object_type'] = 'command'
             else:
                 preview_kwargs['object_type'] = 'command group'
-
-            del preview_kwargs['_get_tag']
-            del preview_kwargs['_get_message']
             self.preview_info = ImplicitPreviewItem(**preview_kwargs)
 
     def load(self, options):

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -10,6 +10,7 @@ import sys
 from collections import defaultdict
 
 from .deprecation import ImplicitDeprecated, resolve_deprecate_info
+from .preview import ImplicitPreviewItem, resolve_preview_info
 from .util import CLIError, CtxTypeError, CommandResultItem, todict
 from .parser import CLICommandParser
 from .commands import CLICommandsLoader
@@ -117,6 +118,7 @@ class CommandInvoker(object):
             err = sys.exc_info()[1]
             getattr(parsed_ns, '_parser', self.parser).validation_error(str(err))
 
+    # pylint: disable=too-many-statements
     def execute(self, args):
         """ Executes the command invocation
 
@@ -184,7 +186,19 @@ class CommandInvoker(object):
             del deprecate_kwargs['_get_message']
             deprecations.append(ImplicitDeprecated(**deprecate_kwargs))
 
-        # TODO: search for implicit preview?
+        # search for implicit preview
+        path_comps = cmd.name.split()[:-1]
+        implicit_preview_info = None
+        while path_comps and not implicit_preview_info:
+            implicit_preview_info = resolve_preview_info(self.cli_ctx, ' '.join(path_comps))
+            del path_comps[-1]
+
+        if implicit_preview_info:
+            preview_kwargs = implicit_preview_info.__dict__.copy()
+            preview_kwargs['object_type'] = 'command'
+            del preview_kwargs['_get_tag']
+            del preview_kwargs['_get_message']
+            previews.append(ImplicitPreviewItem(**preview_kwargs))
 
         colorama.init()
         for d in deprecations:

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -164,6 +164,10 @@ class CommandInvoker(object):
         if cmd.deprecate_info:
             deprecations.append(cmd.deprecate_info)
 
+        previews = getattr(parsed_args, '_argument_previews', [])
+        if cmd.preview_info:
+            previews.append(cmd.preview_info)
+
         params = self._filter_params(parsed_args)
 
         # search for implicit deprecation
@@ -180,9 +184,13 @@ class CommandInvoker(object):
             del deprecate_kwargs['_get_message']
             deprecations.append(ImplicitDeprecated(**deprecate_kwargs))
 
+        # TODO: search for implicit preview?
+
         colorama.init()
         for d in deprecations:
             print(d.message, file=sys.stderr)
+        for p in previews:
+            print(p.message, file=sys.stderr)
         colorama.deinit()
 
         cmd_result = parsed_args.func(params)

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -196,8 +196,6 @@ class CommandInvoker(object):
         if implicit_preview_info:
             preview_kwargs = implicit_preview_info.__dict__.copy()
             preview_kwargs['object_type'] = 'command'
-            del preview_kwargs['_get_tag']
-            del preview_kwargs['_get_message']
             previews.append(ImplicitPreviewItem(**preview_kwargs))
 
         colorama.init()

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -170,6 +170,7 @@ class CLICommandParser(argparse.ArgumentParser):
                     param = CLICommandParser._add_argument(command_parser, arg)
                 param.completer = arg.completer
                 param.deprecate_info = arg.deprecate_info
+                param.preview_info = arg.preview_info
             command_parser.set_defaults(
                 func=metadata,
                 command=command_name,

--- a/knack/preview.py
+++ b/knack/preview.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from six import string_types as STRING_TYPES
-
 from .util import ColorizedString
 
 _PREVIEW_TAG = '[Preview]'
@@ -76,8 +74,8 @@ class PreviewItem(object):
                     raise
         return result
 
+    # pylint: disable=no-self-use
     def hidden(self):
-        # TODO: consult config file?
         return False
 
     def show_in_help(self):

--- a/knack/preview.py
+++ b/knack/preview.py
@@ -5,9 +5,10 @@
 
 from six import string_types as STRING_TYPES
 
+from .util import ColorizedString
 
-_DEFAULT_PREVIEW_TAG = '(PREVIEW)'
-_preview_kwarg_name = 'is_preview'
+_PREVIEW_TAG = '[Preview]'
+_preview_kwarg = 'preview_info'
 
 
 def resolve_preview_info(cli_ctx, name):
@@ -21,48 +22,31 @@ def resolve_preview_info(cli_ctx, name):
     preview_info = None
     try:
         command = _get_command(name)
-        preview_info = getattr(command, _preview_kwarg_name, None)
+        preview_info = getattr(command, _preview_kwarg, None)
     except KeyError:
         command_group = _get_command_group(name)
         group_kwargs = getattr(command_group, 'group_kwargs', None)
         if group_kwargs:
-            preview_info = group_kwargs.get(_preview_kwarg_name, None)
+            preview_info = group_kwargs.get(_preview_kwarg, None)
     return preview_info
-
-
-class ColorizedString(object):
-
-    def __init__(self, message, color):
-        import colorama
-        self._message = message
-        self._color = getattr(colorama.Fore, color.upper(), None)
-
-    def __len__(self):
-        return len(self._message)
-
-    def __str__(self):
-        import colorama
-        if not self._color:
-            return self._message
-        return self._color + self._message + colorama.Fore.RESET
 
 
 # pylint: disable=too-many-instance-attributes
 class PreviewItem(object):
 
     def __init__(self, cli_ctx=None, object_type='', target=None, tag_func=None, message_func=None):
-        """ Create a collection of deprecation metadata.
+        """ Create a collection of preview metadata.
 
-        :param cli_ctx: The CLI context associated with the deprecated item.
+        :param cli_ctx: The CLI context associated with the preview item.
         :type cli_ctx: knack.cli.CLI
-        :param object_type: A label describing the type of object being deprecated.
+        :param object_type: A label describing the type of object in preview.
         :type: object_type: str
-        :param target: The name of the object being deprecated.
+        :param target: The name of the object in preview.
         :type target: str
-        :param tag_func: Callable which returns the desired unformatted tag string for the deprecated item.
+        :param tag_func: Callable which returns the desired unformatted tag string for the preview item.
                          Omit to use the default.
         :type tag_func: callable
-        :param message_func: Callable which returns the desired unformatted message string for the deprecated item.
+        :param message_func: Callable which returns the desired unformatted message string for the preview item.
                              Omit to use the default.
         :type message_func: callable
         """
@@ -71,10 +55,9 @@ class PreviewItem(object):
         self.target = target
 
         def _default_get_message(self):
-            return "This {} is in preview and may be altered or removed " \
-                   "in the future without warning.".format(self.object_type)
+            return "This {} is in preview. It may be changed/removed in a future release.".format(self.object_type)
 
-        self._get_tag = tag_func or (lambda _: _DEFAULT_PREVIEW_TAG)
+        self._get_tag = tag_func or (lambda _: _PREVIEW_TAG)
         self._get_message = message_func or _default_get_message
 
     def __deepcopy__(self, memo):
@@ -93,9 +76,12 @@ class PreviewItem(object):
                     raise
         return result
 
+    def hidden(self):
+        # TODO: consult config file?
+        return False
+
     def show_in_help(self):
-        # TODO: read config file to see if preview items should be shown?
-        return True
+        return not self.hidden()
 
     @property
     def tag(self):
@@ -113,8 +99,8 @@ class ImplicitPreviewItem(PreviewItem):
     def __init__(self, **kwargs):
 
         def get_implicit_preview_message(self):
-            return "This {} is in preview because command group '{}' is in preview. " \
-                   "It may be altered or removed without warning in a future release.".format(self.object_type, self.target)
+            return "Command group '{}' is in preview. It may be changed/removed " \
+                   "in a future release.".format(self.target)
 
         kwargs.update({
             'tag_func': lambda _: '',

--- a/knack/preview.py
+++ b/knack/preview.py
@@ -1,0 +1,123 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from six import string_types as STRING_TYPES
+
+
+_DEFAULT_PREVIEW_TAG = '(PREVIEW)'
+_preview_kwarg_name = 'is_preview'
+
+
+def resolve_preview_info(cli_ctx, name):
+
+    def _get_command(name):
+        return cli_ctx.invocation.commands_loader.command_table[name]
+
+    def _get_command_group(name):
+        return cli_ctx.invocation.commands_loader.command_group_table.get(name, None)
+
+    preview_info = None
+    try:
+        command = _get_command(name)
+        preview_info = getattr(command, _preview_kwarg_name, None)
+    except KeyError:
+        command_group = _get_command_group(name)
+        group_kwargs = getattr(command_group, 'group_kwargs', None)
+        if group_kwargs:
+            preview_info = group_kwargs.get(_preview_kwarg_name, None)
+    return preview_info
+
+
+class ColorizedString(object):
+
+    def __init__(self, message, color):
+        import colorama
+        self._message = message
+        self._color = getattr(colorama.Fore, color.upper(), None)
+
+    def __len__(self):
+        return len(self._message)
+
+    def __str__(self):
+        import colorama
+        if not self._color:
+            return self._message
+        return self._color + self._message + colorama.Fore.RESET
+
+
+# pylint: disable=too-many-instance-attributes
+class PreviewItem(object):
+
+    def __init__(self, cli_ctx=None, object_type='', target=None, tag_func=None, message_func=None):
+        """ Create a collection of deprecation metadata.
+
+        :param cli_ctx: The CLI context associated with the deprecated item.
+        :type cli_ctx: knack.cli.CLI
+        :param object_type: A label describing the type of object being deprecated.
+        :type: object_type: str
+        :param target: The name of the object being deprecated.
+        :type target: str
+        :param tag_func: Callable which returns the desired unformatted tag string for the deprecated item.
+                         Omit to use the default.
+        :type tag_func: callable
+        :param message_func: Callable which returns the desired unformatted message string for the deprecated item.
+                             Omit to use the default.
+        :type message_func: callable
+        """
+        self.cli_ctx = cli_ctx
+        self.object_type = object_type
+        self.target = target
+
+        def _default_get_message(self):
+            return "This {} is in preview and may be altered or removed " \
+                   "in the future without warning.".format(self.object_type)
+
+        self._get_tag = tag_func or (lambda _: _DEFAULT_PREVIEW_TAG)
+        self._get_message = message_func or _default_get_message
+
+    def __deepcopy__(self, memo):
+        import copy
+
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            try:
+                setattr(result, k, copy.deepcopy(v, memo))
+            except TypeError:
+                if k == 'cli_ctx':
+                    setattr(result, k, self.cli_ctx)
+                else:
+                    raise
+        return result
+
+    def show_in_help(self):
+        # TODO: read config file to see if preview items should be shown?
+        return True
+
+    @property
+    def tag(self):
+        """ Returns a tag object. """
+        return ColorizedString(self._get_tag(self), 'cyan')
+
+    @property
+    def message(self):
+        """ Returns a tuple with the formatted message string and the message length. """
+        return ColorizedString(self._get_message(self), 'cyan')
+
+
+class ImplicitPreviewItem(PreviewItem):
+
+    def __init__(self, **kwargs):
+
+        def get_implicit_preview_message(self):
+            return "This {} is in preview because command group '{}' is in preview. " \
+                   "It may be altered or removed without warning in a future release.".format(self.object_type, self.target)
+
+        kwargs.update({
+            'tag_func': lambda _: '',
+            'message_func': get_implicit_preview_message
+        })
+        super(ImplicitPreviewItem, self).__init__(**kwargs)

--- a/knack/util.py
+++ b/knack/util.py
@@ -52,6 +52,51 @@ class ColorizedString(object):
         return self._color + self._message + colorama.Fore.RESET
 
 
+class TagDecorator(object):
+
+    # pylint: disable=unused-argument
+    def __init__(self, cli_ctx, object_type, target, tag_func, message_func, color, **kwargs):
+        self.cli_ctx = cli_ctx
+        self.object_type = object_type
+        self.target = target
+        self._color = color
+        self._get_tag = tag_func
+        self._get_message = message_func
+
+    def __deepcopy__(self, memo):
+        import copy
+
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            try:
+                setattr(result, k, copy.deepcopy(v, memo))
+            except TypeError:
+                if k == 'cli_ctx':
+                    setattr(result, k, self.cli_ctx)
+                else:
+                    raise
+        return result
+
+    # pylint: disable=no-self-use
+    def hidden(self):
+        return False
+
+    def show_in_help(self):
+        return not self.hidden()
+
+    @property
+    def tag(self):
+        """ Returns a tag object. """
+        return ColorizedString(self._get_tag(self), self._color)
+
+    @property
+    def message(self):
+        """ Returns a tuple with the formatted message string and the message length. """
+        return ColorizedString(self._get_message(self), self._color)
+
+
 def ensure_dir(d):
     """ Create a directory if it doesn't exist """
     if not os.path.isdir(d):

--- a/knack/util.py
+++ b/knack/util.py
@@ -35,6 +35,23 @@ class CtxTypeError(TypeError):
                                                                                    obj.__class__.__name__))
 
 
+class ColorizedString(object):
+
+    def __init__(self, message, color):
+        import colorama
+        self._message = message
+        self._color = getattr(colorama.Fore, color.upper(), None)
+
+    def __len__(self):
+        return len(self._message)
+
+    def __str__(self):
+        import colorama
+        if not self._color:
+            return self._message
+        return self._color + self._message + colorama.Fore.RESET
+
+
 def ensure_dir(d):
     """ Create a directory if it doesn't exist """
     if not os.path.isdir(d):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = '0.6.1'
+VERSION = '0.6.2'
 
 DEPENDENCIES = [
     'argcomplete',

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -38,9 +38,9 @@ class TestCommandPreview(unittest.TestCase):
             def load_command_table(self, args):
                 super(PreviewTestCommandLoader, self).load_command_table(args)
                 with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
-                    g.command('cmd1', 'example_handler', preview_info=g.preview())
+                    g.command('cmd1', 'example_handler', is_preview=True)
 
-                with CommandGroup(self, 'grp1', '{}#{{}}'.format(__name__), preview_info=self.preview()) as g:
+                with CommandGroup(self, 'grp1', '{}#{{}}'.format(__name__), is_preview=True) as g:
                     g.command('cmd1', 'example_handler')
 
                 return self.command_table
@@ -96,7 +96,7 @@ class TestCommandGroupPreview(unittest.TestCase):
             def load_command_table(self, args):
                 super(PreviewTestCommandLoader, self).load_command_table(args)
 
-                with CommandGroup(self, 'group1', '{}#{{}}'.format(__name__), preview_info=self.preview()) as g:
+                with CommandGroup(self, 'group1', '{}#{{}}'.format(__name__), is_preview=True) as g:
                     g.command('cmd1', 'example_handler')
 
                 return self.command_table
@@ -160,7 +160,7 @@ class TestArgumentPreview(unittest.TestCase):
 
             def load_arguments(self, command):
                 with ArgumentsContext(self, 'arg-test') as c:
-                    c.argument('arg1', help='Arg1', preview_info=c.preview())
+                    c.argument('arg1', help='Arg1', is_preview=True)
 
                 super(PreviewTestCommandLoader, self).load_arguments(command)
 
@@ -179,7 +179,7 @@ class TestArgumentPreview(unittest.TestCase):
         expected = """
 Arguments
     --arg1 [Preview] [Required] : Arg1.
-        Argument 'arg1' is in preview. It may be changed/removed in a future release.
+        Argument '--arg1' is in preview. It may be changed/removed in a future release.
 """.format(self.cli_ctx.name)
         self.assertIn(expected, actual)
 
@@ -188,7 +188,7 @@ Arguments
         """ Ensure deprecated arguments can be used. """
         self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar'.split())
         actual = self.io.getvalue()
-        expected = "Argument 'arg1' is in preview. It may be changed/removed in a future release."
+        expected = "Argument '--arg1' is in preview. It may be changed/removed in a future release."
         self.assertIn(expected, actual)
 
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,196 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from __future__ import unicode_literals
+
+import unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+from threading import Lock
+
+from knack.arguments import ArgumentsContext
+from knack.commands import CLICommand, CLICommandsLoader, CommandGroup
+
+from tests.util import DummyCLI, redirect_io
+
+
+def example_handler(arg1, arg2=None, arg3=None):
+    """ Short summary here. Long summary here. Still long summary. """
+    pass
+
+
+def example_arg_handler(arg1, opt1, arg2=None, opt2=None, arg3=None,
+                        opt3=None, arg4=None, opt4=None, arg5=None, opt5=None):
+    pass
+
+
+class TestCommandPreview(unittest.TestCase):
+
+    def setUp(self):
+
+        from knack.help_files import helps
+
+        class PreviewTestCommandLoader(CLICommandsLoader):
+            def load_command_table(self, args):
+                super(PreviewTestCommandLoader, self).load_command_table(args)
+                with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
+                    g.command('cmd1', 'example_handler', preview_info=g.preview())
+
+                with CommandGroup(self, 'grp1', '{}#{{}}'.format(__name__), preview_info=self.preview()) as g:
+                    g.command('cmd1', 'example_handler')
+
+                return self.command_table
+
+            def load_arguments(self, command):
+                with ArgumentsContext(self, '') as c:
+                    c.argument('arg1', options_list=['--arg', '-a'], required=False, type=int, choices=[1, 2, 3])
+                    c.argument('arg2', options_list=['-b'], required=True, choices=['a', 'b', 'c'])
+
+                super(PreviewTestCommandLoader, self).load_arguments(command)
+
+        helps['grp1'] = """
+    type: group
+    short-summary: A group.
+"""
+        self.cli_ctx = DummyCLI(commands_loader_cls=PreviewTestCommandLoader)
+
+    @redirect_io
+    def test_preview_command_group_help(self):
+        """ Ensure preview commands appear correctly in group help view. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('-h'.split())
+        actual = self.io.getvalue()
+        expected = u"""
+Group
+    {}
+
+Subgroups:
+    grp1 [Preview] : A group.
+
+Commands:
+    cmd1 [Preview] : Short summary here.
+
+""".format(self.cli_ctx.name)
+        self.assertEqual(expected, actual)
+
+    @redirect_io
+    def test_preview_command_plain_execute(self):
+        """ Ensure general warning displayed when running preview command. """
+        self.cli_ctx.invoke('cmd1 -b b'.split())
+        actual = self.io.getvalue()
+        expected = "This command is in preview. It may be changed/removed in a future release."
+        self.assertIn(expected, actual)
+
+
+class TestCommandGroupPreview(unittest.TestCase):
+
+    def setUp(self):
+
+        from knack.help_files import helps
+
+        class PreviewTestCommandLoader(CLICommandsLoader):
+            def load_command_table(self, args):
+                super(PreviewTestCommandLoader, self).load_command_table(args)
+
+                with CommandGroup(self, 'group1', '{}#{{}}'.format(__name__), preview_info=self.preview()) as g:
+                    g.command('cmd1', 'example_handler')
+
+                return self.command_table
+
+            def load_arguments(self, command):
+                with ArgumentsContext(self, '') as c:
+                    c.argument('arg1', options_list=['--arg', '-a'], required=False, type=int, choices=[1, 2, 3])
+                    c.argument('arg2', options_list=['-b'], required=True, choices=['a', 'b', 'c'])
+
+                super(PreviewTestCommandLoader, self).load_arguments(command)
+
+        helps['group1'] = """
+    type: group
+    short-summary: A group.
+"""
+        self.cli_ctx = DummyCLI(commands_loader_cls=PreviewTestCommandLoader)
+
+    @redirect_io
+    def test_preview_command_group_help_plain(self):
+        """ Ensure help warnings appear for preview command group help. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('group1 -h'.split())
+        actual = self.io.getvalue()
+        expected = """
+Group
+    cli group1 : A group.
+        This command group is in preview. It may be changed/removed in a future release.
+Commands:
+    cmd1 : Short summary here.
+
+""".format(self.cli_ctx.name)
+        self.assertEqual(expected, actual)
+
+    @redirect_io
+    def test_preview_command_implicitly(self):
+        """ Ensure help warning displayed for command in preview because of a preview parent group. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('group1 cmd1 -h'.split())
+        actual = self.io.getvalue()
+        expected = """
+Command
+    {} group1 cmd1 : Short summary here.
+        Long summary here. Still long summary. Command group 'group1' is in preview. It may be
+        changed/removed in a future release.
+""".format(self.cli_ctx.name)
+        self.assertIn(expected, actual)
+
+
+class TestArgumentPreview(unittest.TestCase):
+
+    def setUp(self):
+
+        from knack.help_files import helps
+
+        class PreviewTestCommandLoader(CLICommandsLoader):
+            def load_command_table(self, args):
+                super(PreviewTestCommandLoader, self).load_command_table(args)
+                with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
+                    g.command('arg-test', 'example_arg_handler')
+                return self.command_table
+
+            def load_arguments(self, command):
+                with ArgumentsContext(self, 'arg-test') as c:
+                    c.argument('arg1', help='Arg1', preview_info=c.preview())
+
+                super(PreviewTestCommandLoader, self).load_arguments(command)
+
+        helps['grp1'] = """
+    type: group
+    short-summary: A group.
+"""
+        self.cli_ctx = DummyCLI(commands_loader_cls=PreviewTestCommandLoader)
+
+    @redirect_io
+    def test_preview_arguments_command_help(self):
+        """ Ensure preview arguments appear correctly in command help view. """
+        with self.assertRaises(SystemExit):
+            self.cli_ctx.invoke('arg-test -h'.split())
+        actual = self.io.getvalue()
+        expected = """
+Arguments
+    --arg1 [Preview] [Required] : Arg1.
+        Argument 'arg1' is in preview. It may be changed/removed in a future release.
+""".format(self.cli_ctx.name)
+        self.assertIn(expected, actual)
+
+    @redirect_io
+    def test_preview_arguments_execute(self):
+        """ Ensure deprecated arguments can be used. """
+        self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar'.split())
+        actual = self.io.getvalue()
+        expected = "Argument 'arg1' is in preview. It may be changed/removed in a future release."
+        self.assertIn(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Allows command authors to designate that commands, command groups, and arguments are in a preview state, similar to the existing deprecation mechanism.