### PR TITLE
Ensure usages of ~ also use os.path.expanduser.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ We recommend specifying `cli_name`, `config_dir` and `config_env_var_prefix`.
 
 For example:
 `cli_name` - Name of CLI. Typically the executable name.
-`config_dir` - Path to config dir. e.g. `os.path.join('~', '.myconfig')`
+`config_dir` - Path to config dir. e.g. `os.path.expanduser(os.path.join('~', '.myconfig'))`
 `config_env_var_prefix` - A prefix for environment variables used in config e.g. `CLI_`.
 
 Use the `invoke()` method to invoke commands.

--- a/examples/exapp
+++ b/examples/exapp
@@ -79,7 +79,7 @@ class MyCommandsLoader(CLICommandsLoader):
 
 
 mycli = CLI(cli_name=cli_name,
-            config_dir=os.path.join('~', '.{}'.format(cli_name)),
+            config_dir=os.path.expanduser(os.path.join('~', '.{}'.format(cli_name))),
             config_env_var_prefix=cli_name,
             commands_loader_cls=MyCommandsLoader,
             help_cls=MyCLIHelp)

--- a/examples/exapp2
+++ b/examples/exapp2
@@ -86,7 +86,7 @@ class MyCLI(CLI):
 
 
 mycli = MyCLI(cli_name=cli_name,
-              config_dir=os.path.join('~', '.{}'.format(cli_name)),
+              config_dir=os.path.expanduser(os.path.join('~', '.{}'.format(cli_name))),
               config_env_var_prefix=cli_name,
               commands_loader_cls=MyCommandsLoader,
               help_cls=MyCLIHelp)

--- a/examples/test_exapp
+++ b/examples/test_exapp
@@ -47,7 +47,7 @@ class MyCommandsLoader(CLICommandsLoader):
 name = 'exapp4'
 
 mycli = CLI(cli_name=name,
-            config_dir=os.path.join('~', '.{}'.format(name)),
+            config_dir=os.path.expanduser(os.path.join('~', '.{}'.format(name))),
             config_env_var_prefix=name,
             commands_loader_cls=MyCommandsLoader)
 

--- a/knack/config.py
+++ b/knack/config.py
@@ -21,7 +21,7 @@ class CLIConfig(object):
                        '0': False, 'no': False, 'false': False, 'off': False}
 
     _DEFAULT_CONFIG_ENV_VAR_PREFIX = 'CLI'
-    _DEFAULT_CONFIG_DIR = os.path.join('~', '.{}'.format('cli'))
+    _DEFAULT_CONFIG_DIR = os.path.expanduser(os.path.join('~', '.{}'.format('cli')))
     _DEFAULT_CONFIG_FILE_NAME = 'config'
     _CONFIG_DEFAULTS_SECTION = 'defaults'
 

--- a/tests/test_cli_scenarios.py
+++ b/tests/test_cli_scenarios.py
@@ -87,7 +87,7 @@ class TestCLIScenarios(unittest.TestCase):
                 self.command_table['abc list'] = CLICommand(self.cli_ctx, 'abc list', a_test_command_handler)
                 return OrderedDict(self.command_table)
 
-        mycli = CLI(cli_name='exapp1', config_dir=os.path.join('~', '.exapp1'), commands_loader_cls=MyCommandsLoader)
+        mycli = CLI(cli_name='exapp1', config_dir=os.path.expanduser(os.path.join('~', '.exapp1')), commands_loader_cls=MyCommandsLoader)
 
         expected_output = """[
   {


### PR DESCRIPTION
Prevents creating a `~` directory on Windows.