### PR TITLE
Fix target logic for preview mechanism

### DIFF
--- a/knack/arguments.py
+++ b/knack/arguments.py
@@ -256,7 +256,7 @@ class ArgumentsContext(object):
             # convert argument dest
             target = '--{}'.format(argument_dest.replace('_', '-'))
         elif options_list:
-            target = sorted(options_list, key=len)[0]
+            target = sorted(options_list, key=len)[-1]
         else:
             # positional argument
             target = kwargs.get('metavar', '<{}>'.format(argument_dest.upper()))


### PR DESCRIPTION
Ensures that the longest option is used as target, not the shortest!