### PR TITLE
Fix warning/deprecated msg indentation in help text

### DIFF
--- a/knack/help.py
+++ b/knack/help.py
@@ -382,9 +382,9 @@ class CLIHelp(object):
             if item.long_summary:
                 lines.append(item.long_summary)
             if item.deprecate_info:
-                lines.append(''.join(['\n', str(item.deprecate_info.message)]))
+                lines.append('\n' + str(item.deprecate_info.message))
             if item.preview_info:
-                lines.append(''.join(['\n', str(item.preview_info.message)]))
+                lines.append('\n' + str(item.preview_info.message))
             return ' '.join(lines)
 
         indent += 1

--- a/knack/help.py
+++ b/knack/help.py
@@ -379,12 +379,15 @@ class CLIHelp(object):
 
         def _build_long_summary(item):
             lines = []
+            skip_line = ''
             if item.long_summary:
                 lines.append(item.long_summary)
+                skip_line = '\n'
             if item.deprecate_info:
-                lines.append('\n' + str(item.deprecate_info.message))
+                lines.append(skip_line + str(item.deprecate_info.message))
+                skip_line = '\n'
             if item.preview_info:
-                lines.append('\n' + str(item.preview_info.message))
+                lines.append(skip_line + str(item.preview_info.message))
             return ' '.join(lines)
 
         indent += 1

--- a/knack/help.py
+++ b/knack/help.py
@@ -379,16 +379,13 @@ class CLIHelp(object):
 
         def _build_long_summary(item):
             lines = []
-            skip_line = ''
             if item.long_summary:
                 lines.append(item.long_summary)
-                skip_line = '\n'
             if item.deprecate_info:
-                lines.append(skip_line + str(item.deprecate_info.message))
-                skip_line = '\n'
+                lines.append(str(item.deprecate_info.message))
             if item.preview_info:
-                lines.append(skip_line + str(item.preview_info.message))
-            return ' '.join(lines)
+                lines.append(str(item.preview_info.message))
+            return '\n'.join(lines)
 
         indent += 1
         long_sum = _build_long_summary(help_file)

--- a/knack/help.py
+++ b/knack/help.py
@@ -382,9 +382,9 @@ class CLIHelp(object):
             if item.long_summary:
                 lines.append(item.long_summary)
             if item.deprecate_info:
-                lines.append(str(item.deprecate_info.message))
+                lines.append(''.join(['\n', str(item.deprecate_info.message)]))
             if item.preview_info:
-                lines.append(str(item.preview_info.message))
+                lines.append(''.join(['\n', str(item.preview_info.message)]))
             return ' '.join(lines)
 
         indent += 1

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -93,8 +93,9 @@ Commands:
         expected = """
 Command
     {} cmd3 : Short summary here.
-        Long summary here. Still long summary. This command has been deprecated and will be
-        removed in a future release. Use 'alt-cmd3' instead.
+        Long summary here. Still long summary.
+        This command has been deprecated and will be removed in a future release. Use 'alt-
+        cmd3' instead.
 
 Arguments
     -b [Required] : Allowed values: a, b, c.
@@ -245,9 +246,9 @@ Group
         expected = """
 Command
     {} group1 cmd1 : Short summary here.
-        Long summary here. Still long summary. This command is implicitly deprecated because
-        command group 'group1' is deprecated and will be removed in a future release. Use 'alt-
-        group1' instead.
+        Long summary here. Still long summary.
+        This command is implicitly deprecated because command group 'group1' is deprecated and
+        will be removed in a future release. Use 'alt-group1' instead.
 """.format(self.cli_ctx.name)
         self.assertIn(expected, actual)
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -141,8 +141,9 @@ Commands:
         expected = """
 Command
     {} group1 cmd1 : Short summary here.
-        Long summary here. Still long summary. Command group 'group1' is in preview. It may be
-        changed/removed in a future release.
+        Long summary here. Still long summary.
+        Command group 'group1' is in preview. It may be changed/removed in a future
+        release.
 """.format(self.cli_ctx.name)
         self.assertIn(expected, actual)
 


### PR DESCRIPTION
Fixes #164 

- Before the fix:
![image](https://user-images.githubusercontent.com/11888714/67283343-1fd72580-f4f1-11e9-8d92-5758d1b6e2af.png)



- After the fix:
![image](https://user-images.githubusercontent.com/11888714/67283254-f8805880-f4f0-11e9-96d0-04d2ab53c96d.png)
