### PR TITLE
fix: CI broken by pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '2.7'
 - '3.5'
 - '3.6'
+- '3.7'
 install: pip install tox-travis
 script: tox
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 - '2.7'
 - '3.5'
 - '3.6'
-- '3.7'
 install: pip install tox-travis
 script: tox
 deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ pyyaml==3.12
 six==1.10.0
 tabulate==0.7.7
 vcrpy==1.10.3
-pytest==3.3.1
-attrs==19.1.0
+pytest==4.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ six==1.10.0
 tabulate==0.7.7
 vcrpy==1.10.3
 pytest==3.3.1
+attrs==19.1.0


### PR DESCRIPTION
As https://github.com/microsoft/knack/pull/168 pointed out, CI has been broken because of pytest dependency.

Fix as suggest from https://github.com/pytest-dev/pytest/issues/5903 via upgrading pytest to 4.6.6