### PR TITLE
Stop using random temp folders in tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@
 import os
 import stat
 import unittest
-import tempfile
+import shutil
 try:
     import mock
 except ImportError:
@@ -14,12 +14,24 @@ except ImportError:
 from six.moves import configparser
 
 from knack.config import CLIConfig, get_config_parser
+from .util import TEMP_FOLDER_NAME, new_temp_folder
+
+
+def clean_local_temp_folder():
+    local_temp_folders = os.path.join(os.getcwd(), TEMP_FOLDER_NAME)
+    if os.path.exists(local_temp_folders):
+        shutil.rmtree(local_temp_folders)
 
 
 class TestCLIConfig(unittest.TestCase):
 
     def setUp(self):
-        self.cli_config = CLIConfig(config_dir=tempfile.mkdtemp())
+        self.cli_config = CLIConfig(config_dir=new_temp_folder())
+        # In case the previous test is stopped and doesn't clean up
+        clean_local_temp_folder()
+
+    def tearDown(self):
+        clean_local_temp_folder()
 
     def test_has_option(self):
         section = 'MySection'

--- a/tests/util.py
+++ b/tests/util.py
@@ -9,9 +9,14 @@ except ImportError:
     from unittest import mock
 import sys
 import tempfile
+import shutil
+import os
 from six import StringIO
 
 from knack.cli import CLI, CLICommandsLoader, CommandInvoker
+
+TEMP_FOLDER_NAME = "knack_temp"
+
 
 def redirect_io(func):
 
@@ -30,7 +35,7 @@ def redirect_io(func):
 class MockContext(CLI):
 
     def __init__(self):
-        super(MockContext, self).__init__(config_dir=tempfile.mkdtemp())
+        super(MockContext, self).__init__(config_dir=new_temp_folder())
         loader = CLICommandsLoader(cli_ctx=self)
         invocation = mock.MagicMock(spec=CommandInvoker)
         invocation.data = {}
@@ -44,5 +49,13 @@ class DummyCLI(CLI):
         return '0.1.0'
 
     def __init__(self, **kwargs):
-        kwargs['config_dir'] = tempfile.mkdtemp()
+        kwargs['config_dir'] = new_temp_folder()
         super(DummyCLI, self).__init__(**kwargs)
+
+
+def new_temp_folder():
+    temp_dir = os.path.join(tempfile.gettempdir(), TEMP_FOLDER_NAME)
+    if os.path.exists(temp_dir):
+        shutil.rmtree(temp_dir)
+    os.mkdir(temp_dir)
+    return temp_dir


### PR DESCRIPTION
Originally, each time the full test is run (`pytest` or `tox`), it will generate ~20 temporary folders `tmp*` under 

1. User's temp folder: `C:\Users\{}\AppData\Local\Temp`
2. Working directory

This PR removes the usage of random temp folders and unify all tests to use `C:\Users\{}\AppData\Local\Temp\knack_temp` as user's temp folder and cleans the temp folder under the working directory. 

Note this change will invalidate parallel tests, but this is fine given the number of tests is small and we are not using parallel test anyway.