### PR TITLE
Handle getcwd FileNotFoundError

### DIFF
--- a/knack/config.py
+++ b/knack/config.py
@@ -47,7 +47,16 @@ class CLIConfig(object):
         self.defaults_section_name = CLIConfig._CONFIG_DEFAULTS_SECTION
         self.use_local_config = use_local_config
         self._config_file_chain = []
-        current_dir = os.getcwd()
+
+        current_dir = None
+        try:
+            current_dir = os.getcwd()
+        except FileNotFoundError:
+            from .log import get_logger
+            logger = get_logger()
+            logger.warning("The working directory has been deleted or recreated. "
+                           "Local config is ignored.")
+
         config_dir_name = os.path.basename(self.config_dir)
         while current_dir:
             current_config_dir = os.path.join(current_dir, config_dir_name)


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/12239

On Linux, if the working directory has been deleted (or created later), `getcwd` will raise `FileNotFoundError`.

This PR fixes this issue by showing a warning and continue.

To test, run

```
mkdir t1
cd t1
rmdir ~/t1
python ~/knack/examples/exapp2 abc list
```

Now it shows warning:

> The working directory has been deleted or recreated. Local config is ignored.

In Azure CLI, the warning appears twice because besides the initiation of `CLIConfig` from Knack

https://github.com/microsoft/knack/blob/2036b788db968eab274cc22625bce50f4611d00c/knack/cli.py#L83-L86

Azure CLI is also creating a `CLIConfig` instance. 

https://github.com/Azure/azure-cli/blob/77fcc2b071bd448e858807946e4f2ef66db9ae4e/src/azure-cli-core/azure/cli/core/extension/__init__.py#L16

```py
az_config = CLIConfig(config_dir=GLOBAL_CONFIG_DIR, config_env_var_prefix=ENV_VAR_PREFIX)
```

We may fix it in Azure CLI later.