### PR TITLE
Show warning when UnicodeEncodeError is raised

### DIFF
--- a/knack/output.py
+++ b/knack/output.py
@@ -160,6 +160,8 @@ class OutputProducer(object):
             else:
                 raise
         except UnicodeEncodeError:
+            logger.warning("Unable to encode the output with %s encoding. Unsupported characters are discarded.",
+                           out_file.encoding)
             print(output.encode('ascii', 'ignore').decode('utf-8', 'ignore'),
                   file=out_file, end='')
 


### PR DESCRIPTION
Show warning when `UnicodeEncodeError` is raised.

To test, on Windows go to **Control Panel > Region > Administrative > Change system local** and use English. Do not check **Beta: Use Unicode UTF-8 for worldwide language support**.

Open PowerShell terminal and run

```jsonc
az group show -n testrg
{
  "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/testrg",
  "location": "centralus",
  "managedBy": null,
  "name": "testrg",
  "properties": {
    "provisioningState": "Succeeded"
  },
  "tags": {
    "key0303": "测试€£￥テスト안녕𓀀𓀁𒀉𒅤"
  },
  "type": "Microsoft.Resources/resourceGroups"
}
```

The output is correct, but if the output is redirected, PowerShell uses the system encoding. Thus `az` will silently remove the value of `key0303`:

```jsonc
> $t = az group show -n testrg
> $t
{
  "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/testrg",
  "location": "centralus",
  "managedBy": null,
  "name": "testrg",
  "properties": {
    "provisioningState": "Succeeded"
  },
  "tags": {
    "key0303": ""   // value is removed
  },
  "type": "Microsoft.Resources/resourceGroups"
}
```

The solution is any of 

1. Remove invalid characters under the current locale
2. Use a locale that supports those special characters
3. Check **Beta: Use Unicode UTF-8 for worldwide language support**

![utf8](https://user-images.githubusercontent.com/4003950/75752152-13968b00-5d63-11ea-82a9-5b8ac4a474eb.png)

If none of the above solution is adopted, Knack will show a warning:

```
> $t = az group show -n testrg
Unable to encode the output with cp1252 encoding. Unsupported characters are discarded.**
```