### PR TITLE
Support --only-show-errors

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -12,6 +12,7 @@ Logging
 - By default, log messages Warning and above are shown to the user.
 - `--verbose` - This flag changes the logging level to Info and above.
 - `--debug` - This flag changes the logging level to Debug and above.
+- `--only-show-errors` - This flag changes the logging level to Error only, suppressing Warning.
 
 * All log messages go to STDERR (not STDOUT)
 * Log to Error or Warning for user messages instead of using the `print()` function

--- a/examples/exapp2
+++ b/examples/exapp2
@@ -28,6 +28,22 @@ helps['abc list'] = """
           text: {cli_name} abc list
 """.format(cli_name=cli_name)
 
+helps['abc first'] = """
+    type: command
+    short-summary: List the first several letters in the alphabet.
+    examples:
+        - name: Show the list of abc
+          text: {cli_name} abc first --number 3
+""".format(cli_name=cli_name)
+
+helps['abc last'] = """
+    type: command
+    short-summary: List the last several letters in the alphabet.
+    examples:
+        - name: Show the list of xyz
+          text: {cli_name} abc last --number 3
+""".format(cli_name=cli_name)
+
 
 def a_test_command_handler():
     return [{'a': 1, 'b': 1234}, {'a': 3, 'b': 4}]
@@ -38,8 +54,54 @@ def abc_list_command_handler():
     return list(string.ascii_lowercase)
 
 
+def abc_first_command_handler(number=5):
+    import string
+    return list(string.ascii_lowercase)[0:number]
+
+
+def abc_last_command_handler(number=5):
+    import string
+    return list(string.ascii_lowercase)[-number:]
+
+
+def num_range_command_handler(start=0, end=5):
+    """
+    Get a list of natural numbers from start to end
+    :param start: the lower bound
+    :param end: the higher bound
+    :return:
+    """
+    return list(range(int(start), int(end) + 1))
+
+
+def sample_json_handler():
+    """
+    Get a sample JSON dict
+    """
+    # https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list#examples
+    result = {
+        "id": "/subscriptions/291bba3f-e0a5-47bc-a099-3bdcb2a50a05",
+        "subscriptionId": "291bba3f-e0a5-47bc-a099-3bdcb2a50a05",
+        "tenantId": "31c75423-32d6-4322-88b7-c478bdde4858",
+        "displayName": "Example Subscription",
+        "state": "Enabled",
+        "subscriptionPolicies": {
+            "locationPlacementId": "Internal_2014-09-01",
+            "quotaId": "Internal_2014-09-01",
+            "spendingLimit": "Off"
+        },
+        "authorizationSource": "RoleBased",
+        "managedByTenants": [
+            {
+                "tenantId": "8f70baf1-1f6e-46a2-a1ff-238dac1ebfb7"
+            }
+        ]
+    }
+    return result
+
 def hello_command_handler(myarg=None, abc=None):
     return ['hello', 'world', myarg, abc]
+
 
 WELCOME_MESSAGE = r"""
    _____ _      _____ 
@@ -67,15 +129,28 @@ class MyCommandsLoader(CLICommandsLoader):
     def load_command_table(self, args):
         with CommandGroup(self, 'hello', '__main__#{}') as g:
             g.command('world', 'hello_command_handler', confirmation=True)
+        with CommandGroup(self, '', '__main__#{}') as g:
+            g.command('sample-json', 'sample_json_handler')
         with CommandGroup(self, 'abc', '__main__#{}') as g:
-                g.command('list', 'abc_list_command_handler')
-                g.command('show', 'a_test_command_handler')
-                g.command('get', 'a_test_command_handler', deprecate_info=g.deprecate(redirect='show', hide='0.1.0'))
+            g.command('list', 'abc_list_command_handler')
+            g.command('show', 'a_test_command_handler')
+            g.command('get', 'a_test_command_handler', deprecate_info=g.deprecate(redirect='show', hide='1.0.0'))
+            g.command('first', 'abc_first_command_handler', is_preview=True)
+            g.command('last', 'abc_last_command_handler', )
+        with CommandGroup(self, 'ga', '__main__#{}') as g:
+            g.command('range', 'num_range_command_handler')
+        with CommandGroup(self, 'pre', '__main__#{}', is_preview=True) as g:
+            g.command('range', 'num_range_command_handler')
+        with CommandGroup(self, 'exp', '__main__#{}', ) as g:
+            g.command('range', 'num_range_command_handler')
         return super(MyCommandsLoader, self).load_command_table(args)
 
     def load_arguments(self, command):
         with ArgumentsContext(self, 'hello world') as ac:
             ac.argument('myarg', type=int, default=100)
+        with ArgumentsContext(self, 'ga range') as ac:
+            ac.argument('start', type=int, is_preview=True)
+            ac.argument('end', type=int, )
         super(MyCommandsLoader, self).load_arguments(command)
 
 

--- a/knack/cli.py
+++ b/knack/cli.py
@@ -91,6 +91,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
         self.output = self.output_cls(cli_ctx=self)
         self.result = None
         self.query = query_cls(cli_ctx=self)
+        self.only_show_errors = False
 
     @staticmethod
     def _should_show_version(args):

--- a/knack/cli.py
+++ b/knack/cli.py
@@ -91,7 +91,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
         self.output = self.output_cls(cli_ctx=self)
         self.result = None
         self.query = query_cls(cli_ctx=self)
-        self.only_show_errors = False
+        self.only_show_errors = self.config.get('core', 'only_show_errors', fallback=False)
         self.enable_color = not self.config.get('core', 'no_color', fallback=False)
 
     @staticmethod

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -139,7 +139,7 @@ class CommandInvoker(object):
         self.parser.load_command_table(self.commands_loader)
         self.cli_ctx.raise_event(EVENT_INVOKER_CMD_TBL_LOADED, parser=self.parser)
 
-        arg_check = [a for a in args if a not in ['--verbose', '--debug']]
+        arg_check = [a for a in args if a not in ['--verbose', '--debug', '--only-show-warnings']]
         if not arg_check:
             self.cli_ctx.completion.enable_autocomplete(self.parser)
             subparser = self.parser.subparsers[tuple()]
@@ -198,12 +198,13 @@ class CommandInvoker(object):
             preview_kwargs['object_type'] = 'command'
             previews.append(ImplicitPreviewItem(**preview_kwargs))
 
-        colorama.init()
-        for d in deprecations:
-            print(d.message, file=sys.stderr)
-        for p in previews:
-            print(p.message, file=sys.stderr)
-        colorama.deinit()
+        if not self.cli_ctx.only_show_errors:
+            colorama.init()
+            for d in deprecations:
+                print(d.message, file=sys.stderr)
+            for p in previews:
+                print(p.message, file=sys.stderr)
+            colorama.deinit()
 
         cmd_result = parsed_args.func(params)
         cmd_result = todict(cmd_result)

--- a/knack/log.py
+++ b/knack/log.py
@@ -132,17 +132,20 @@ class CLILogging(object):
 
     def _determine_log_level(self, args):
         """ Get verbose level by reading the arguments. """
-        self.cli_ctx.only_show_errors = False
-        if CLILogging.ONLY_SHOW_ERRORS_FLAG in args or \
-                self.cli_ctx.config.get('core', 'only_show_errors', fallback=False):
+        # arguments have higher precedence than config
+        if CLILogging.ONLY_SHOW_ERRORS_FLAG in args:
             if CLILogging.DEBUG_FLAG in args or CLILogging.VERBOSE_FLAG in args:
                 raise CLIError("--only-show-errors can't be used together with --debug or --verbose")
             self.cli_ctx.only_show_errors = True
             return 1
         if CLILogging.DEBUG_FLAG in args:
+            self.cli_ctx.only_show_errors = False
             return 4
         if CLILogging.VERBOSE_FLAG in args:
+            self.cli_ctx.only_show_errors = False
             return 3
+        if self.cli_ctx.only_show_errors:
+            return 1
         return 2  # default to show WARNINGs and above
 
     def _init_console_handlers(self, root_logger, cli_logger, log_level_config):

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -98,8 +98,8 @@ Command
         cmd3' instead.
 
 Arguments
-    -b [Required] : Allowed values: a, b, c.
-    --arg -a      : Allowed values: 1, 2, 3.
+    -b      [Required] : Allowed values: a, b, c.
+    --arg -a           : Allowed values: 1, 2, 3.
     --arg3
 """.format(self.cli_ctx.name)
         self.assertIn(expected, actual)

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -295,6 +295,7 @@ Arguments
 Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
+    --only-show-errors   : Only show errors, suppressing warnings.
     --output -o          : Output format.  Allowed values: json, jsonc, none, table, tsv, yaml,
                            yamlc.  Default: json.
     --query              : JMESPath query string. See http://jmespath.org/ for more information and
@@ -322,18 +323,19 @@ Command
         Long summary here. Still long summary.
 
 Arguments
-    -b [Required] : Allowed values: a, b, c.
-    --arg -a      : Allowed values: 1, 2, 3.
+    -b      [Required] : Allowed values: a, b, c.
+    --arg -a           : Allowed values: 1, 2, 3.
     --arg3
 
 Global Arguments
-    --debug       : Increase logging verbosity to show all debug logs.
-    --help -h     : Show this help message and exit.
-    --output -o   : Output format.  Allowed values: json, jsonc, none, table, tsv, yaml, yamlc.
-                    Default: json.
-    --query       : JMESPath query string. See http://jmespath.org/ for more information and
-                    examples.
-    --verbose     : Increase logging verbosity. Use --debug for full debug logs.
+    --debug            : Increase logging verbosity to show all debug logs.
+    --help -h          : Show this help message and exit.
+    --only-show-errors : Only show errors, suppressing warnings.
+    --output -o        : Output format.  Allowed values: json, jsonc, none, table, tsv, yaml, yamlc.
+                         Default: json.
+    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+                         examples.
+    --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
 """
         actual = io.getvalue()
@@ -437,19 +439,20 @@ Command
         Long summary here. Still long summary.
 
 Arguments
-    -b [Required] : Allowed values: a, b, c.
-    --arg -a      : Allowed values: 1, 2, 3.
+    -b      [Required] : Allowed values: a, b, c.
+    --arg -a           : Allowed values: 1, 2, 3.
     --arg3
 
 Global Arguments
-    --debug       : Increase logging verbosity to show all debug logs.
-    --exampl      : This is a new global argument.
-    --help -h     : Show this help message and exit.
-    --output -o   : Output format.  Allowed values: json, jsonc, none, table, tsv, yaml, yamlc.
-                    Default: json.
-    --query       : JMESPath query string. See http://jmespath.org/ for more information and
-                    examples.
-    --verbose     : Increase logging verbosity. Use --debug for full debug logs.
+    --debug            : Increase logging verbosity to show all debug logs.
+    --exampl           : This is a new global argument.
+    --help -h          : Show this help message and exit.
+    --only-show-errors : Only show errors, suppressing warnings.
+    --output -o        : Output format.  Allowed values: json, jsonc, none, table, tsv, yaml, yamlc.
+                         Default: json.
+    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+                         examples.
+    --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
 """
         actual = io.getvalue()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -13,6 +13,7 @@ import colorama
 
 from knack.events import EVENT_PARSER_GLOBAL_CREATE, EVENT_INVOKER_PRE_CMD_TBL_CREATE
 from knack.log import CLILogging, get_logger, CLI_LOGGER_NAME, _CustomStreamHandler
+from knack.util import CLIError
 from tests.util import MockContext
 
 
@@ -39,40 +40,51 @@ class TestLoggingLevel(unittest.TestCase):
         self.mock_ctx = MockContext()
         self.cli_logging = CLILogging('clitest', cli_ctx=self.mock_ctx)
 
-    def test_determine_verbose_level_default(self):
+    def test_determine_log_level_default(self):
         argv = []
-        actual_level = self.cli_logging._determine_verbose_level(argv)  # pylint: disable=protected-access
-        expected_level = 0
+        actual_level = self.cli_logging._determine_log_level(argv)  # pylint: disable=protected-access
+        expected_level = 2
         self.assertEqual(actual_level, expected_level)
 
-    def test_determine_verbose_level_verbose(self):
+    def test_determine_log_level_verbose(self):
         argv = ['--verbose']
-        actual_level = self.cli_logging._determine_verbose_level(argv)  # pylint: disable=protected-access
-        expected_level = 1
+        actual_level = self.cli_logging._determine_log_level(argv)  # pylint: disable=protected-access
+        expected_level = 3
         self.assertEqual(actual_level, expected_level)
 
-    def test_determine_verbose_level_debug(self):
+    def test_determine_log_level_debug(self):
         argv = ['--debug']
-        actual_level = self.cli_logging._determine_verbose_level(argv)  # pylint: disable=protected-access
-        expected_level = 2
+        actual_level = self.cli_logging._determine_log_level(argv)  # pylint: disable=protected-access
+        expected_level = 4
         self.assertEqual(actual_level, expected_level)
 
-    def test_determine_verbose_level_v_v_v_default(self):
+    def test_determine_log_level_v_v_v_default(self):
         argv = ['--verbose', '--debug']
-        actual_level = self.cli_logging._determine_verbose_level(argv)  # pylint: disable=protected-access
-        expected_level = 2
+        actual_level = self.cli_logging._determine_log_level(argv)  # pylint: disable=protected-access
+        expected_level = 4
         self.assertEqual(actual_level, expected_level)
 
-    def test_determine_verbose_level_other_args_verbose(self):
-        argv = ['account', '--verbose']
-        actual_level = self.cli_logging._determine_verbose_level(argv)  # pylint: disable=protected-access
+    def test_determine_log_level_only_show_errors(self):
+        argv = ['--only-show-errors']
+        actual_level = self.cli_logging._determine_log_level(argv)  # pylint: disable=protected-access
         expected_level = 1
         self.assertEqual(actual_level, expected_level)
 
-    def test_determine_verbose_level_other_args_debug(self):
+    def test_determine_log_level_all_flags(self):
+        argv = ['--verbose', '--debug', '--only-show-errors']
+        with self.assertRaises(CLIError):
+            self.cli_logging._determine_log_level(argv)  # pylint: disable=protected-access
+
+    def test_determine_log_level_other_args_verbose(self):
+        argv = ['account', '--verbose']
+        actual_level = self.cli_logging._determine_log_level(argv)  # pylint: disable=protected-access
+        expected_level = 3
+        self.assertEqual(actual_level, expected_level)
+
+    def test_determine_log_level_other_args_debug(self):
         argv = ['account', '--debug']
-        actual_level = self.cli_logging._determine_verbose_level(argv)  # pylint: disable=protected-access
-        expected_level = 2
+        actual_level = self.cli_logging._determine_log_level(argv)  # pylint: disable=protected-access
+        expected_level = 4
         self.assertEqual(actual_level, expected_level)
 
     def test_get_cli_logger(self):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -70,6 +70,14 @@ class TestLoggingLevel(unittest.TestCase):
         expected_level = 1
         self.assertEqual(actual_level, expected_level)
 
+    def test_determine_log_level_only_show_errors_config(self):
+        argv = []
+        self.mock_ctx.only_show_errors = True
+        actual_level = self.cli_logging._determine_log_level(argv)  # pylint: disable=protected-access
+        expected_level = 1
+        self.assertEqual(actual_level, expected_level)
+        self.mock_ctx.only_show_errors = False
+
     def test_determine_log_level_all_flags(self):
         argv = ['--verbose', '--debug', '--only-show-errors']
         with self.assertRaises(CLIError):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -97,18 +97,14 @@ Commands:
         self.assertNotIn("preview", actual)
 
         # Apply --only-show-errors with config
+        self.cli_ctx.only_show_errors = True
         self.cli_ctx.config.set_value('core', 'only_show_errors', 'True')
         self.cli_ctx.invoke('cmd1 -b b'.split())
         actual = self.io.getvalue()
         self.assertNotIn("preview", actual)
         self.cli_ctx.config.set_value('core', 'only_show_errors', '')
+        self.cli_ctx.only_show_errors = False
 
-        # Apply --only-show-errors with env var
-        os.environ["CLI_CORE_ONLY_SHOW_ERRORS"] = "True"
-        self.cli_ctx.invoke('cmd1 -b b'.split())
-        actual = self.io.getvalue()
-        self.assertNotIn("preview", actual)
-        del(os.environ["CLI_CORE_ONLY_SHOW_ERRORS"])
 
     @redirect_io
     @disable_color


### PR DESCRIPTION
Support `--only-show-errors` to disable warnings, including **preview**, **deprecation** warnings during command invocation and `logger.warning()`.

There are 3 ways to achieve this effect:

- Use `--only-show-errors` as command parameter
- Use config
    ```
    [core]
    only_show_errors=True
    ```
- Use env var `CLI_CORE_ONLY_SHOW_ERRORS=True`

It appears in every command's `--help` message:

```
Global Arguments
    ...
    --only-show-errors : Only show errors, suppressing warnings.
    ...
```

