### PR TITLE
Add back python 3.5 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 python:
+- '3.5'
 - '3.6'
 - '3.7'
 - '3.8'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ Release History
 +++++
 * Allow disabling color (#171)
 * Support yaml and yamlc output (#173)
-* Drop support for python 2 and 3.5 (#174)
+* Drop support for python 2 (#174)
 * Support ``--only-show-errors`` to disable warnings (#179)
 * Add experimental tag (#180)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ Release History
 +++++
 * Allow disabling color (#171)
 * Support yaml and yamlc output (#173)
-* Drop support for python 2 (#174)
+* Drop support for python 2 (#174, #183)
 * Support ``--only-show-errors`` to disable warnings (#179)
 * Add experimental tag (#180)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py35,py36,py37,py38
 [testenv]
 deps = -rrequirements.txt
 commands=


### PR DESCRIPTION
Revert part of https://github.com/microsoft/knack/pull/174 to add python 3.5 back, as there are still many people using Python 3.5: https://w3techs.com/technologies/details/pl-python/3