### PR TITLE
{Packaging} Remove universal=1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 license_files = LICENSE


### PR DESCRIPTION
Same as https://github.com/Azure/azure-cli/pull/12683

Remove `universal=1` so that PyPI doesn't mark the package as Python 2 supported: 

https://pypi.org/project/knack/#files

knack-0.6.3-py2.py3-none-any.whl (54.8 kB) | Wheel | py2.py3
-- | -- | --
