### PR TITLE
Remove python < 3.4 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,4 @@ setup(
     ],
     packages=['knack', 'knack.testsdk'],
     install_requires=DEPENDENCIES,
-    extras_require={
-        ':python_version<"3.4"': ['enum34']
-    }
 )

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(
         'License :: OSI Approved :: MIT License',
     ],
     packages=['knack', 'knack.testsdk'],
-    install_requires=DEPENDENCIES,
+    install_requires=DEPENDENCIES
 )


### PR DESCRIPTION
As the oldest supported is python 3.5 it does not make sense to pull in enum34.