### PR TITLE
Bump PyYAML version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ jmespath==0.9.4
 mock==4.0.1
 pylint==2.3.0
 Pygments==2.5.2
-PyYAML==5.3
+PyYAML==5.3.1
 six==1.14.0
 tabulate==0.8.6
 vcrpy==4.0.2


### PR DESCRIPTION
Fix #193 

Bump PyYAML version to fix [CVE-2020-1747](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1747).
