### PR TITLE
Change experimental tag color to cyan

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.7.0rc2
++++++
+* Change experimental tag color to cyan
+
 0.7.0rc1
 +++++
 * Allow disabling color (#171)

--- a/knack/experimental.py
+++ b/knack/experimental.py
@@ -57,7 +57,7 @@ class ExperimentalItem(StatusTag):
             cli_ctx=cli_ctx,
             object_type=object_type,
             target=target,
-            color='red',
+            color='cyan',
             tag_func=tag_func or (lambda _: _EXPERIMENTAL_TAG),
             message_func=message_func or _default_get_message
         )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = '0.7.0rc1'
+VERSION = '0.7.0rc2'
 
 DEPENDENCIES = [
     'argcomplete',


### PR DESCRIPTION
Change **experimental** tag color to cyan, which **preview** tag uses:

https://github.com/microsoft/knack/blob/5f0bcc2ae416c8f2834db71b49040976e1d7a29d/knack/preview.py#L59
