### PR TITLE
Refine the timing to raise EVENT_CLI_POST_EXECUTE event and catch SystemExit

### DIFF
--- a/knack/cli.py
+++ b/knack/cli.py
@@ -219,14 +219,19 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
                 if cmd_result and cmd_result.result is not None:
                     formatter = self.output.get_formatter(output_type)
                     self.output.out(cmd_result, formatter=formatter, out_file=out_file)
-            self.raise_event(EVENT_CLI_POST_EXECUTE)
         except KeyboardInterrupt as ex:
             self.result = CommandResultItem(None, error=ex)
             exit_code = 1
         except Exception as ex:  # pylint: disable=broad-except
             exit_code = self.exception_handler(ex)
             self.result = CommandResultItem(None, error=ex)
+        except SystemExit as ex:
+            exit_code = self.exception_handler(ex)
+            self.result = CommandResultItem(None, error=ex)
+            raise ex
         finally:
+            self.raise_event(EVENT_CLI_POST_EXECUTE)
+
             if self.enable_color:
                 colorama.deinit()
         self.result.exit_code = exit_code


### PR DESCRIPTION
1.  make application be aware of the SystemExit exception
2.  Move a final event EVENT_CLI_POST_EXECUTE to `finally` statement to let application be aware of the final existing event and be able to register callbacks to do something.