### PR TITLE
Expose several remove functions in ConfigFile & Support write notice in config file

### DIFF
--- a/knack/config.py
+++ b/knack/config.py
@@ -205,13 +205,13 @@ class _ConfigFile(object):
     def remove_option(self, section, option):
         config = get_config_parser()
         config.read(self.config_path)
-        ret = False
+        existed = False
         try:
-            ret = config.remove_option(section, option)
+            existed = config.remove_option(section, option)
             self.set(config)
         except configparser.NoSectionError:
             pass
-        return ret
+        return existed
 
     def remove_section(self, section):
         config = get_config_parser()

--- a/knack/config.py
+++ b/knack/config.py
@@ -225,7 +225,7 @@ class _ConfigFile(object):
         config = get_config_parser()
         config.read(self.config_path)
         for section in config.sections():
-           config.remove_section(section)
+            config.remove_section(section)
         self.set(config)
 
     def sections(self):

--- a/knack/config.py
+++ b/knack/config.py
@@ -203,30 +203,26 @@ class _ConfigFile(object):
         self.set(config)
 
     def remove_option(self, section, option):
-        config = get_config_parser()
-        config.read(self.config_path)
         existed = False
-        try:
-            existed = config.remove_option(section, option)
-            self.set(config)
-        except configparser.NoSectionError:
-            pass
+        if self.config_parser:
+            try:
+                existed = self.config_parser.remove_option(section, option)
+                self.set(self.config_parser)
+            except configparser.NoSectionError:
+                pass
         return existed
 
     def remove_section(self, section):
-        config = get_config_parser()
-        config.read(self.config_path)
-        if config.remove_section(section):
-            self.set(config)
+        if self.config_parser and self.config_parser.remove_section(section):
+            self.set(self.config_parser)
             return True
         return False
 
     def clear(self):
-        config = get_config_parser()
-        config.read(self.config_path)
-        for section in config.sections():
-            config.remove_section(section)
-        self.set(config)
+        if self.config_parser:
+            for section in self.config_parser.sections():
+                self.config_parser.remove_section(section)
+            self.set(self.config_parser)
 
     def sections(self):
         return self.config_parser.sections()

--- a/knack/config.py
+++ b/knack/config.py
@@ -148,17 +148,17 @@ class _ConfigFile(object):
                        '0': False, 'no': False, 'false': False, 'off': False}
 
     def __init__(self, config_dir, config_path, config_comment=None):
-        """ Manages configuration options available in the CLI
+        """ Manage configuration options available in the CLI
 
-        :param config_dir: The directory to store config file
+        :param config_dir: The directory to store the config file
         :type config_dir: str
-        :param config_path: The path of config file
+        :param config_path: The path of the config file
         :type config_path: str
-        :param config_comment: The comment which will be written into head of config file
+        :param config_comment: The comment which will be written into the head of the config file
         :type config_comment: str
 
         When 'config_comment' is given, each line should start with # or ;. For details about INI file comment,
-        you can reference this link https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
+        see https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
         """
         self.config_dir = config_dir
         self.config_path = config_path

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,9 +11,9 @@ try:
     import mock
 except ImportError:
     from unittest import mock
-from six.moves import configparser
+import configparser
 
-from knack.config import CLIConfig, get_config_parser
+from knack.config import CLIConfig
 from .util import TEMP_FOLDER_NAME, new_temp_folder
 
 
@@ -171,7 +171,7 @@ class TestCLIConfig(unittest.TestCase):
 
     def test_set_config_value(self):
         self.cli_config.set_value('test_section', 'test_option', 'a_value')
-        config = get_config_parser()
+        config = configparser.ConfigParser()
         config.read(self.cli_config.config_path)
         self.assertEqual(config.get('test_section', 'test_option'), 'a_value')
 


### PR DESCRIPTION
Previously, there are only `get` and `set` function in `_ConfigFile`, we can't remove section/option from a config file. Thus we have to set value to empty string if we want to remove a entry. Add `remove_section` and `remove_option` function here for the case we need to remove these entries.

Also add a notice property for ConfigFile, if we pass a notice, it will be wrote to head to the file.