### PR TITLE
Add a default_value_source property in HelpParameter

### DIFF
--- a/knack/arguments.py
+++ b/knack/arguments.py
@@ -45,7 +45,7 @@ class CLIArgumentType(object):
 class CLICommandArgument(object):
 
     NAMED_ARGUMENTS = ['options_list', 'validator', 'completer', 'arg_group', 'deprecate_info', 'preview_info',
-                       'experimental_info', 'default_from']
+                       'experimental_info', 'default_value_source']
 
     def __init__(self, dest=None, argtype=None, **kwargs):
         """An argument that has a specific destination parameter.

--- a/knack/arguments.py
+++ b/knack/arguments.py
@@ -45,7 +45,7 @@ class CLIArgumentType(object):
 class CLICommandArgument(object):
 
     NAMED_ARGUMENTS = ['options_list', 'validator', 'completer', 'arg_group', 'deprecate_info', 'preview_info',
-                       'experimental_info']
+                       'experimental_info', 'default_from']
 
     def __init__(self, dest=None, argtype=None, **kwargs):
         """An argument that has a specific destination parameter.

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -99,6 +99,7 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
             logger.info("Configured default '%s' for arg %s", config_value, arg.name)
             overrides.settings['default'] = DefaultStr(config_value)
             overrides.settings['required'] = False
+            overrides.settings['default_from'] = 'Configure'
 
     def load_arguments(self):
         if self.arguments_loader:

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -99,7 +99,7 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
             logger.info("Configured default '%s' for arg %s", config_value, arg.name)
             overrides.settings['default'] = DefaultStr(config_value)
             overrides.settings['required'] = False
-            overrides.settings['default_from'] = 'Configure'
+            overrides.settings['default_value_source'] = 'Configure'
 
     def load_arguments(self):
         if self.arguments_loader:

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -99,7 +99,7 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
             logger.info("Configured default '%s' for arg %s", config_value, arg.name)
             overrides.settings['default'] = DefaultStr(config_value)
             overrides.settings['required'] = False
-            overrides.settings['default_value_source'] = 'Configure'
+            overrides.settings['default_value_source'] = 'Config'
 
     def load_arguments(self):
         if self.arguments_loader:

--- a/knack/help.py
+++ b/knack/help.py
@@ -319,7 +319,8 @@ class CommandHelpFile(HelpFile):
             'name_source': normal_options,
             'deprecate_info': getattr(param, 'deprecate_info', None),
             'preview_info': getattr(param, 'preview_info', None),
-            'experimental_info': getattr(param, 'experimental_info', None)
+            'experimental_info': getattr(param, 'experimental_info', None),
+            'default_from': getattr(param, 'default_from', None)
         })
         self.parameters.append(HelpParameter(**param_kwargs))
 
@@ -342,8 +343,8 @@ class CommandHelpFile(HelpFile):
 
 class HelpParameter(HelpObject):  # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, name_source, description, required, choices=None,
-                 default=None, group_name=None, deprecate_info=None, preview_info=None, experimental_info=None):
+    def __init__(self, name_source, description, required, choices=None, default=None, group_name=None,
+                 deprecate_info=None, preview_info=None, experimental_info=None, default_from=None):
         super(HelpParameter, self).__init__()
         self.name_source = name_source
         self.name = ' '.join(sorted(name_source))
@@ -358,6 +359,7 @@ class HelpParameter(HelpObject):  # pylint: disable=too-many-instance-attributes
         self.deprecate_info = deprecate_info
         self.preview_info = preview_info
         self.experimental_info = experimental_info
+        self.default_from = default_from
 
     def update_from_data(self, data):
         if self.name != data.get('name'):

--- a/knack/help.py
+++ b/knack/help.py
@@ -320,7 +320,7 @@ class CommandHelpFile(HelpFile):
             'deprecate_info': getattr(param, 'deprecate_info', None),
             'preview_info': getattr(param, 'preview_info', None),
             'experimental_info': getattr(param, 'experimental_info', None),
-            'default_from': getattr(param, 'default_from', None)
+            'default_value_source': getattr(param, 'default_value_source', None)
         })
         self.parameters.append(HelpParameter(**param_kwargs))
 
@@ -344,7 +344,7 @@ class CommandHelpFile(HelpFile):
 class HelpParameter(HelpObject):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, name_source, description, required, choices=None, default=None, group_name=None,
-                 deprecate_info=None, preview_info=None, experimental_info=None, default_from=None):
+                 deprecate_info=None, preview_info=None, experimental_info=None, default_value_source=None):
         super(HelpParameter, self).__init__()
         self.name_source = name_source
         self.name = ' '.join(sorted(name_source))
@@ -359,7 +359,7 @@ class HelpParameter(HelpObject):  # pylint: disable=too-many-instance-attributes
         self.deprecate_info = deprecate_info
         self.preview_info = preview_info
         self.experimental_info = experimental_info
-        self.default_from = default_from
+        self.default_value_source = default_value_source
 
     def update_from_data(self, data):
         if self.name != data.get('name'):

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -27,7 +27,8 @@ ARGPARSE_SUPPORTED_KWARGS = [
     'required',
     'help',
     'metavar',
-    'action'
+    'action',
+    'default_from'
 ]
 
 
@@ -174,6 +175,7 @@ class CLICommandParser(argparse.ArgumentParser):
                 param.deprecate_info = arg.deprecate_info
                 param.preview_info = arg.preview_info
                 param.experimental_info = arg.experimental_info
+                param.default_from = arg.default_from
             command_parser.set_defaults(
                 func=metadata,
                 command=command_name,

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -28,7 +28,7 @@ ARGPARSE_SUPPORTED_KWARGS = [
     'help',
     'metavar',
     'action',
-    'default_from'
+    'default_value_source'
 ]
 
 
@@ -175,7 +175,7 @@ class CLICommandParser(argparse.ArgumentParser):
                 param.deprecate_info = arg.deprecate_info
                 param.preview_info = arg.preview_info
                 param.experimental_info = arg.experimental_info
-                param.default_from = arg.default_from
+                param.default_value_source = arg.default_value_source
             command_parser.set_defaults(
                 func=metadata,
                 command=command_name,


### PR DESCRIPTION
Previously, both default value from function default and `az configure` will all display as `Default:`, we want to divide these different source. Add this property to save the default value source. It will be displayed in the help message.