### PR TITLE
Lazily import unnecessary modules

### DIFF
--- a/knack/log.py
+++ b/knack/log.py
@@ -5,7 +5,6 @@
 
 import os
 import logging
-from logging.handlers import RotatingFileHandler
 
 from .util import CtxTypeError, ensure_dir, CLIError
 from .events import EVENT_PARSER_GLOBAL_CREATE
@@ -159,6 +158,7 @@ class CLILogging(object):
     def _init_logfile_handlers(self, root_logger, cli_logger):
         ensure_dir(self.log_dir)
         log_file_path = os.path.join(self.log_dir, self.logfile_name)
+        from logging.handlers import RotatingFileHandler
         logfile_handler = RotatingFileHandler(log_file_path, maxBytes=10 * 1024 * 1024, backupCount=5)
         lfmt = logging.Formatter('%(process)d : %(asctime)s : %(levelname)s : %(name)s : %(message)s')
         logfile_handler.setFormatter(lfmt)

--- a/knack/output.py
+++ b/knack/output.py
@@ -11,7 +11,6 @@ import traceback
 import sys
 from collections import OrderedDict
 from six import StringIO, text_type, u, string_types
-import yaml
 
 from .util import CLIError, CommandResultItem, CtxTypeError
 from .events import EVENT_INVOKER_POST_PARSE_ARGS, EVENT_PARSER_GLOBAL_CREATE
@@ -48,6 +47,7 @@ def format_json_color(obj):
 
 
 def format_yaml(obj):
+    import yaml
     try:
         return yaml.safe_dump(obj.result, default_flow_style=False, allow_unicode=True)
     except yaml.representer.RepresenterError:


### PR DESCRIPTION
Lazily import unnecessary modules to boost performance by 100ms.

```
python -X importtime -c "import knack" 2>perf.log
tuna perf.log
```

Before:

![image](https://user-images.githubusercontent.com/4003950/81176259-7f050f00-8fd7-11ea-97b2-b9e6e97e4f40.png)

After:

![image](https://user-images.githubusercontent.com/4003950/81176327-99d78380-8fd7-11ea-9d02-3c8a80f6b903.png)

