### PR TITLE
rollback get_config_parser for backward compatibility

### DIFF
--- a/knack/config.py
+++ b/knack/config.py
@@ -11,6 +11,10 @@ from .util import ensure_dir
 _UNSET = object()
 
 
+def get_config_parser():
+    return configparser.ConfigParser()  # keep this for backward compatibility
+
+
 class CLIConfig(object):
     _BOOLEAN_STATES = {'1': True, 'yes': True, 'true': True, 'on': True,
                        '0': False, 'no': False, 'false': False, 'off': False}


### PR DESCRIPTION
In previous PR, `get_config_parser` was removed because package `six` was removed and we can use `configparser.ConfigParser` directly. All previous `get_config_parser` in `azure-cli` are updated. However there is some extension which is not owned by CLI team (such as azure-devops) still use this function.

For compatibility concern, it's better to keep this simple function.