### PR TITLE
[Color] Detect isatty when enabling color

### DIFF
--- a/knack/cli.py
+++ b/knack/cli.py
@@ -196,7 +196,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
             logger.exception(ex)
         return 1
 
-    def print_init_log(self):
+    def _print_init_log(self):
         """Print the debug/info log from CLI.__init__"""
         if self.init_debug_log:
             logger.debug('__init__ debug log:\n%s', '\n'.join(self.init_debug_log))
@@ -234,7 +234,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
 
             self.logging.configure(args)
             logger.debug('Command arguments: %s', args)
-            self.print_init_log()
+            self._print_init_log()
 
             self.raise_event(EVENT_CLI_PRE_EXECUTE)
             if CLI._should_show_version(args):

--- a/knack/output.py
+++ b/knack/output.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 import errno
 import json
 import traceback
-import sys
 from collections import OrderedDict
 from six import StringIO, text_type, u, string_types
 
@@ -162,9 +161,9 @@ class OutputProducer(object):
 
     def get_formatter(self, format_type):  # pylint: disable=no-self-use
         # remove color if stdout is not a tty
-        if not sys.stdout.isatty() and format_type == 'jsonc':
+        if not self.cli_ctx.enable_color and format_type == 'jsonc':
             return OutputProducer._FORMAT_DICT['json']
-        if not sys.stdout.isatty() and format_type == 'yamlc':
+        if not self.cli_ctx.enable_color and format_type == 'yamlc':
             return OutputProducer._FORMAT_DICT['yaml']
         return OutputProducer._FORMAT_DICT[format_type]
 

--- a/knack/util.py
+++ b/knack/util.py
@@ -151,3 +151,18 @@ def todict(obj, post_processor=None):  # pylint: disable=too-many-return-stateme
                   if not callable(v) and not k.startswith('_')}
         return post_processor(obj, result) if post_processor else result
     return obj
+
+
+def isatty(stream):
+    # Code copied from
+    # https://github.com/tartley/colorama/blob/3d8d48a95de10be25b161c914f274ec6c41d3129/colorama/ansitowin32.py#L43-L53
+    import sys
+    if 'PYCHARM_HOSTED' in os.environ:
+        if stream is not None and (stream is sys.__stdout__ or stream is sys.__stderr__):
+            return True
+    try:
+        stream_isatty = stream.isatty
+    except AttributeError:
+        return False
+    else:
+        return stream_isatty()

--- a/knack/util.py
+++ b/knack/util.py
@@ -151,18 +151,3 @@ def todict(obj, post_processor=None):  # pylint: disable=too-many-return-stateme
                   if not callable(v) and not k.startswith('_')}
         return post_processor(obj, result) if post_processor else result
     return obj
-
-
-def isatty(stream):
-    # Code copied from
-    # https://github.com/tartley/colorama/blob/3d8d48a95de10be25b161c914f274ec6c41d3129/colorama/ansitowin32.py#L43-L53
-    import sys
-    if 'PYCHARM_HOSTED' in os.environ:
-        if stream is not None and (stream is sys.__stdout__ or stream is sys.__stderr__):
-            return True
-    try:
-        stream_isatty = stream.isatty
-    except AttributeError:
-        return False
-    else:
-        return stream_isatty()

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -5,32 +5,13 @@
 
 import sys
 import unittest
+
 import mock
-from six import StringIO
-
-
-from knack.help import ArgumentGroupRegistry, HelpObject
 from knack.arguments import ArgumentsContext
-from knack.commands import CLICommand, CLICommandsLoader, CommandGroup
+from knack.commands import CLICommandsLoader, CommandGroup
 from knack.events import EVENT_PARSER_GLOBAL_CREATE
-from knack.invocation import CommandInvoker
-
-from tests.util import MockContext, DummyCLI
-
-io = {}
-
-
-def redirect_io(func):
-    def wrapper(self):
-        global io
-        old_stdout = sys.stdout
-        old_stderr = sys.stderr
-        sys.stdout = sys.stderr = io = StringIO()
-        func(self)
-        io.close()
-        sys.stdout = old_stdout
-        sys.stderr = old_stderr
-    return wrapper
+from knack.help import ArgumentGroupRegistry, HelpObject
+from tests.util import DummyCLI, redirect_io
 
 
 def example_handler(arg1, arg2=None, arg3=None):
@@ -206,7 +187,7 @@ class TestHelp(unittest.TestCase):
         """ Ensure choice_list works with integer lists. """
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('n1 -h'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = 'Allowed values: 1, 2, 3'
         self.assertIn(expected, actual)
 
@@ -227,7 +208,7 @@ class TestHelp(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('n1 -h'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = '\nCommand\n    {} n1 : Short summary here.\n        Long summary here. Still long summary.'.format(self.cli_ctx.name)
         self.assertTrue(actual.startswith(expected))
 
@@ -238,7 +219,7 @@ class TestHelp(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('n2 -h'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = '\nCommand\n    {} n2 : YAML short summary.\n        YAML long summary. More summary.'.format(self.cli_ctx.name)
         self.assertTrue(actual.startswith(expected))
 
@@ -248,7 +229,7 @@ class TestHelp(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             self.cli_ctx.invoke('n3 -h'.split())
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = '\nCommand\n    {} n3 : Short summary here.\n        Line1\n        line2.\n'.format(self.cli_ctx.name)
         self.assertTrue(actual.startswith(expected))
 
@@ -269,7 +250,7 @@ Arguments
         Paragraph(s).
     --foobar3            : The foobar3.
 """
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = expected.format(self.cli_ctx.name)
         self.assertTrue(actual.startswith(expected))
 
@@ -307,7 +288,7 @@ Examples
         example details
 
 """
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = expected.format(self.cli_ctx.name)
         self.assertTrue(actual.startswith(expected))
 
@@ -338,7 +319,7 @@ Global Arguments
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
 """
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = expected.format(self.cli_ctx.name)
         self.assertEqual(actual, expected)
 
@@ -358,7 +339,7 @@ Subgroups:
     beta
 
 """
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = expected.format(self.cli_ctx.name)
         self.assertEqual(actual, expected)
 
@@ -377,7 +358,7 @@ Subgroups:
             with self.assertRaises(SystemExit):
                 self.cli_ctx.invoke('n1 -a 1 --arg 2'.split())
 
-            actual = io.getvalue()
+            actual = self.io.getvalue()
             self.assertTrue('required' in actual and '-b' in actual)
 
     @redirect_io
@@ -395,7 +376,7 @@ Subgroups:
             with self.assertRaises(SystemExit):
                 self.cli_ctx.invoke('n1 -a 1 -b c -c extra'.split())
 
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = 'unrecognized arguments: -c extra'
         self.assertIn(expected, actual)
 
@@ -415,7 +396,7 @@ Commands:
     n1 : This module does xyz one-line or so.
 
 """
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = expected.format(self.cli_ctx.name)
         self.assertEqual(actual, expected)
 
@@ -455,7 +436,7 @@ Global Arguments
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
 """
-        actual = io.getvalue()
+        actual = self.io.getvalue()
         expected = s.format(self.cli_ctx.name)
         self.assertEqual(actual, expected)
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -277,17 +277,16 @@ qwerty  0b1f6472qwerty  True
         result = format_tsv(CommandResultItem([obj1, obj2]))
         self.assertEqual(result, '1\t2\n3\t4\n')
 
-    @mock.patch('sys.stdout.isatty', autospec=True)
-    def test_remove_color_no_tty(self, mock_isatty):
+    def test_remove_color_no_tty(self):
         output_producer = OutputProducer(cli_ctx=self.mock_ctx)
 
-        mock_isatty.return_value = False
+        self.mock_ctx.enable_color = False
         formatter = output_producer.get_formatter('jsonc')
         self.assertEqual(formatter, format_json)
         formatter = output_producer.get_formatter('yamlc')
         self.assertEqual(formatter, format_yaml)
 
-        mock_isatty.return_value = True
+        self.mock_ctx.enable_color = True
         formatter = output_producer.get_formatter('jsonc')
         self.assertEqual(formatter, format_json_color)
         formatter = output_producer.get_formatter('yamlc')


### PR DESCRIPTION
This PR is an improvement to https://github.com/microsoft/knack/pull/171.

Only enable color if all of the below conditions stand:

### Color is not explicitly disabled

`AZURE_CORE_NO_COLOR` and this config shouldn't be set:

```ini
[core]
no_color = yes
``` 


### `stdout` is a TTY

Otherwise (enable color while `stdout` is redirected), if the downstream command doesn't support color, Knack will fail with `BrokenPipeError: [Errno 32] Broken pipe` (https://github.com/Azure/azure-cli/issues/13413):

```
$ az --version | head --lines=1
azure-cli                          2.5.1
The command failed with an unexpected error. Here is the traceback:

[Errno 32] Broken pipe
Traceback (most recent call last):
  File "/opt/az/lib/python3.6/site-packages/knack/cli.py", line 207, in invoke
    self.show_version()
  File "/opt/az/lib/python3.6/site-packages/azure/cli/core/__init__.py", line 146, in show_version
    print('\n' + (SURVEY_PROMPT_COLOR if self.enable_color else SURVEY_PROMPT))
  File "/opt/az/lib/python3.6/site-packages/colorama/ansitowin32.py", line 41, in write
    self.__convertor.write(text)
  File "/opt/az/lib/python3.6/site-packages/colorama/ansitowin32.py", line 162, in write
    self.write_and_convert(text)
  File "/opt/az/lib/python3.6/site-packages/colorama/ansitowin32.py", line 187, in write_and_convert
    self.write_plain_text(text, cursor, start)
  File "/opt/az/lib/python3.6/site-packages/colorama/ansitowin32.py", line 196, in write_plain_text
    self.wrapped.flush()
BrokenPipeError: [Errno 32] Broken pipe

To open an issue, please run: 'az feedback'
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
```

With this RP, color sequences are not printed or sent to downstream command.

```
$ az --version | head --lines=1
azure-cli                          2.5.1
```

Also, if color is written to `stderr`, the terminal color can't revert back (https://github.com/Azure/azure-cli/issues/6080, https://github.com/Azure/azure-cli/issues/8483, https://github.com/Azure/azure-cli/issues/11671, https://github.com/Azure/azure-cli/issues/12084, https://github.com/Azure/azure-cli/issues/13979) :

![image](https://user-images.githubusercontent.com/4003950/85098114-35d9e900-b22c-11ea-868e-91647ce7a1da.png)

This is due to colorama issue https://github.com/tartley/colorama/issues/200. In order for color to be reset correctly, the `Style.RESET_ALL` control sequence must be sent to both `stdout` and `stderr`. However, colorama can't send `Style.RESET_ALL` to `stderr` correctly, causing the terminal stuck at the previous color:

```
stdout:  Fore.CYAN  -->    Style.RESET_ALL
stderr:  Fore.RED   -->   (Style.RESET_ALL)   <<< colorama can't send this
```

### `stderr` is a TTY

Otherwise (enable color while `stderr` is redirected),

```
az foo --verbose 2>err.txt
```

`err.txt` will have no level information (because there is no color):

```
az: 'foo' is not in the 'az' command group. See 'az --help'. If the command is from an extension, please make sure the corresponding extension is installed. To learn more about extensions, please visit https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
command ran in 0.559 seconds.
```

With this RP, each message will be prefixed with a LEVEL_TAG - `ERROR`, `WARNING`, `INFO`, `DEBUG`:

```
ERROR: az: 'foo' is not in the 'az' command group. See 'az --help'. If the command is from an extension, please make sure the corresponding extension is installed. To learn more about extensions, please visit https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
INFO: Command ran in 0.917 seconds (init: 0.077, invoke: 0.840)
```
