### PR TITLE
{Refactor} Remove unnecessary cli_ctx reference

### DIFF
--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -84,6 +84,7 @@ class Deprecated(StatusTag):
         self.redirect = redirect
         self.hide = hide
         self.expiration = expiration
+        self._cli_version = cli_ctx.get_cli_version()
 
         super(Deprecated, self).__init__(
             cli_ctx=cli_ctx,
@@ -103,8 +104,7 @@ class Deprecated(StatusTag):
 
     def expired(self):
         if self.expiration:
-            cli_version = self.cli_ctx.get_cli_version()
-            return self._version_less_than_or_equal_to(self.expiration, cli_version)
+            return self._version_less_than_or_equal_to(self.expiration, self._cli_version)
         return False
 
     def hidden(self):
@@ -112,8 +112,7 @@ class Deprecated(StatusTag):
         if isinstance(self.hide, bool):
             hidden = self.hide
         elif isinstance(self.hide, STRING_TYPES):
-            cli_version = self.cli_ctx.get_cli_version()
-            hidden = self._version_less_than_or_equal_to(self.hide, cli_version)
+            hidden = self._version_less_than_or_equal_to(self.hide, self._cli_version)
         return hidden
 
     def show_in_help(self):

--- a/knack/help.py
+++ b/knack/help.py
@@ -153,7 +153,7 @@ class HelpFile(HelpObject):
                 help_ctx.cli_ctx.invocation.commands_loader.command_table else 'command group'
             del deprecate_kwargs['_get_tag']
             del deprecate_kwargs['_get_message']
-            self.deprecate_info = ImplicitDeprecated(**deprecate_kwargs)
+            self.deprecate_info = ImplicitDeprecated(cli_ctx=help_ctx.cli_ctx, **deprecate_kwargs)
 
         # resolve preview info
         direct_preview_info = resolve_preview_info(help_ctx.cli_ctx, delimiters)
@@ -173,7 +173,7 @@ class HelpFile(HelpObject):
                 preview_kwargs['object_type'] = 'command'
             else:
                 preview_kwargs['object_type'] = 'command group'
-            self.preview_info = ImplicitPreviewItem(**preview_kwargs)
+            self.preview_info = ImplicitPreviewItem(cli_ctx=help_ctx.cli_ctx, **preview_kwargs)
 
         # resolve experimental info
         direct_experimental_info = resolve_experimental_info(help_ctx.cli_ctx, delimiters)
@@ -193,7 +193,7 @@ class HelpFile(HelpObject):
                 experimental_kwargs['object_type'] = 'command'
             else:
                 experimental_kwargs['object_type'] = 'command group'
-            self.experimental_info = ImplicitExperimentalItem(**experimental_kwargs)
+            self.experimental_info = ImplicitExperimentalItem(cli_ctx=help_ctx.cli_ctx, **experimental_kwargs)
 
     def load(self, options):
         description = getattr(options, 'description', None)

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -188,7 +188,7 @@ class CommandInvoker(object):
             deprecate_kwargs['object_type'] = 'command'
             del deprecate_kwargs['_get_tag']
             del deprecate_kwargs['_get_message']
-            deprecations.append(ImplicitDeprecated(**deprecate_kwargs))
+            deprecations.append(ImplicitDeprecated(cli_ctx=self.cli_ctx, **deprecate_kwargs))
 
         # search for implicit preview
         path_comps = cmd.name.split()[:-1]
@@ -200,7 +200,7 @@ class CommandInvoker(object):
         if implicit_preview_info:
             preview_kwargs = implicit_preview_info.__dict__.copy()
             preview_kwargs['object_type'] = 'command'
-            previews.append(ImplicitPreviewItem(**preview_kwargs))
+            previews.append(ImplicitPreviewItem(cli_ctx=self.cli_ctx, **preview_kwargs))
 
         # search for implicit experimental
         path_comps = cmd.name.split()[:-1]
@@ -212,7 +212,7 @@ class CommandInvoker(object):
         if implicit_experimental_info:
             experimental_kwargs = implicit_experimental_info.__dict__.copy()
             experimental_kwargs['object_type'] = 'command'
-            experimentals.append(ImplicitExperimentalItem(**experimental_kwargs))
+            experimentals.append(ImplicitExperimentalItem(cli_ctx=self.cli_ctx, **experimental_kwargs))
 
         if not self.cli_ctx.only_show_errors:
             for d in deprecations:

--- a/knack/util.py
+++ b/knack/util.py
@@ -59,28 +59,12 @@ class StatusTag(object):
 
     # pylint: disable=unused-argument
     def __init__(self, cli_ctx, object_type, target, tag_func, message_func, color, **kwargs):
-        self.cli_ctx = cli_ctx
         self.object_type = object_type
         self.target = target
         self._color = color
+        self._enable_color = cli_ctx.enable_color
         self._get_tag = tag_func
         self._get_message = message_func
-
-    def __deepcopy__(self, memo):
-        import copy
-
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-        for k, v in self.__dict__.items():
-            try:
-                setattr(result, k, copy.deepcopy(v, memo))
-            except TypeError:
-                if k == 'cli_ctx':
-                    setattr(result, k, self.cli_ctx)
-                else:
-                    raise
-        return result
 
     # pylint: disable=no-self-use
     def hidden(self):
@@ -92,12 +76,12 @@ class StatusTag(object):
     @property
     def tag(self):
         """ Returns a tag object. """
-        return ColorizedString(self._get_tag(self), self._color) if self.cli_ctx.enable_color else self._get_tag(self)
+        return ColorizedString(self._get_tag(self), self._color) if self._enable_color else self._get_tag(self)
 
     @property
     def message(self):
         """ Returns a tuple with the formatted message string and the message length. """
-        return ColorizedString(self._get_message(self), self._color) if self.cli_ctx.enable_color \
+        return ColorizedString(self._get_message(self), self._color) if self._enable_color \
             else "WARNING: " + self._get_message(self)
 
 


### PR DESCRIPTION
## Description

Remove unnecessary `cli_ctx` reference, which makes `pytest --capture=no` fail:

> RecursionError: maximum recursion depth exceeded

## Root cause

When `pytest` captures `stdout`,

1. `pytest` uses `io.FileIO` to patch `sys.stdout`
2. When initializing `CLI`, `CLI.out_file` points to `io.FileIO` object   
    https://github.com/microsoft/knack/blob/0d0308bc567f2d25654bb39201c02ab262d7ce0a/knack/cli.py#L33
3. `tests.util.redirect_io` uses `io.StringIO` to patch `sys.stdout`, but this doesn't affect the existing `CLI.out_file`

Since `CLI.out_file` doesn't equal `sys.__stdout__` (the original `stdout`), it won't be replaced with a `colorama.ansitowin32.StreamWrapper`:

https://github.com/microsoft/knack/blob/0d0308bc567f2d25654bb39201c02ab262d7ce0a/knack/cli.py#L195-L197

As `PreviewItem` (same for `ExperimentalItem` and `Deprecated`) keeps a reference to `cli_ctx`, during invocation

https://github.com/microsoft/knack/blob/fe3bf5d3a79a3dd2ce5ddb0c38d93843a3380f6f/knack/commands.py#L353

1. `PreviewItem` is deepcopied  ->
2. `cli_ctx` is deepcopied  ->
3. `CLI.out_file` is deepcopied
  
Because `io.FileIO` can't be pickled, `copy.deepcopy` fails and reaches

https://github.com/microsoft/knack/blob/5f0bcc2ae416c8f2834db71b49040976e1d7a29d/knack/util.py#L78-L82

This makes `cli_ctx` not being deepcopied.

However, when `pytest` is called with `pytest --capture=no`, it doesn't patch `sys.stdout`,

1. When initializing `CLI`, `CLI.out_file` equals `sys.__stdout__`
2. `tests.util.redirect_io` uses `io.StringIO` to patch `sys.stdout`, but this doesn't affect the existing `CLI.out_file`


Since `CLI.out_file` equals `sys.__stdout__` (the original `stdout`), it will be replaced with a `colorama.ansitowin32.StreamWrapper` and be deepcopied.

Because of a **circular reference** in `AnsiToWin32`

https://github.com/tartley/colorama/blob/3d8d48a95de10be25b161c914f274ec6c41d3129/colorama/ansitowin32.py#L28-L29

```py
    def __getattr__(self, name):
        return getattr(self.__wrapped, name)
```

and `io.StringIO` can be pickled, when `self.__wrapped` is not set, `deepcopy` fails with exception `RecursionError: maximum recursion depth exceeded`.

To repro, use this simple script:

```py
import colorama
import copy
import sys
import io

sys.stdout = io.StringIO()
colorama.init()
copy.deepcopy(sys.stdout)
```

Or 

```py
class StreamWrapper(object):
    def __init__(self, wrapped, converter):
        # self.__wrapped = wrapped
        self.__convertor = converter

    def __getattr__(self, name):
        return getattr(self.__wrapped, name)


sr = StreamWrapper("a", "b")
hasattr(sr, '__setstate__')
```