### PR TITLE
Update Pylint to 2.5.3

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,13 +3,14 @@
 # W0511 fixme
 # C0111 Missing docstring
 # C0103 Invalid %s name "%s"
+# C0415 Import outside toplevel (import-outside-toplevel)
 # I0011 Warning locally suppressed using disable-msg
 # R0913 Too many arguments
 # R0903 too-few-public-methods
 # R0401 cyclic-import
 # R0205 useless-object-inheritance
 # R1717 consider-using-dict-comprehension
-disable=W0511,C0111,C0103,I0011,R0913,R0903,R0401,R0205,R1717,useless-suppression
+disable=W0511,C0111,C0103,C0415,I0011,R0913,R0903,R0401,R0205,R1717,useless-suppression
 
 [FORMAT]
 max-line-length=120

--- a/knack/config.py
+++ b/knack/config.py
@@ -100,7 +100,7 @@ class CLIConfig(object):
     def items(self, section):
         import re
         pattern = self.env_var_name(section, '.+')
-        candidates = [(k.split('_')[-1], os.environ[k], k) for k in os.environ.keys() if re.match(pattern, k)]
+        candidates = [(k.split('_')[-1], os.environ[k], k) for k in os.environ if re.match(pattern, k)]
         result = {c[0]: c for c in candidates}
         for config in self._config_file_chain if self.use_local_config else self._config_file_chain[-1:]:
             try:
@@ -180,7 +180,7 @@ class _ConfigFile(object):
     def get(self, section, option):
         if self.config_parser:
             return self.config_parser.get(section, option)
-        raise configparser.NoOptionError(section, option)
+        raise configparser.NoOptionError(option, section)
 
     def getint(self, section, option):
         return int(self.get(section, option))

--- a/knack/introspection.py
+++ b/knack/introspection.py
@@ -54,10 +54,9 @@ def option_descriptions(operation):
             temp = lines[index].strip()
             if any(temp.startswith(x) for x in param_breaks):
                 break
-            else:
-                if temp:
-                    arg_desc += (' ' + temp)
-                index += 1
+            if temp:
+                arg_desc += (' ' + temp)
+            index += 1
 
         option_descs[arg_name] = arg_desc
 

--- a/knack/testsdk/base.py
+++ b/knack/testsdk/base.py
@@ -179,7 +179,7 @@ class ScenarioTest(IntegrationTestBase):  # pylint: disable=too-many-instance-at
     @classmethod
     def _custom_request_query_matcher(cls, r1, r2):
         """ Ensure method, path, and query parameters match. """
-        from six.moves.urllib_parse import urlparse, parse_qs  # pylint: disable=relative-import, useless-suppression
+        from six.moves.urllib_parse import urlparse, parse_qs  # pylint: disable=useless-suppression
 
         url1 = urlparse(r1.uri)
         url2 = urlparse(r2.uri)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama==0.4.3
 flake8==3.7.9
 jmespath==0.9.5
 mock==4.0.1
-pylint==2.3.0
+pylint==2.5.3
 Pygments==2.5.2
 PyYAML==5.3.1
 six==1.14.0


### PR DESCRIPTION
CI was broken due to a breaking change in `isort` https://github.com/timothycrosley/isort/issues/1273:

```
py36 run-test: commands[2] | pylint knack --rcfile=.pylintrc -r n -d I0013
Traceback (most recent call last):
  File "/home/vsts/work/1/s/.tox/py36/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "/home/vsts/work/1/s/.tox/py36/lib/python3.6/site-packages/pylint/__init__.py", line 20, in run_pylint
    Run(sys.argv[1:])
  File "/home/vsts/work/1/s/.tox/py36/lib/python3.6/site-packages/pylint/lint.py", line 1628, in __init__
    linter.check(args)
  File "/home/vsts/work/1/s/.tox/py36/lib/python3.6/site-packages/pylint/lint.py", line 943, in check
    self._do_check(files_or_modules)
  File "/home/vsts/work/1/s/.tox/py36/lib/python3.6/site-packages/pylint/lint.py", line 1075, in _do_check
    self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
  File "/home/vsts/work/1/s/.tox/py36/lib/python3.6/site-packages/pylint/lint.py", line 1158, in check_astroid_module
    walker.walk(ast_node)
  File "/home/vsts/work/1/s/.tox/py36/lib/python3.6/site-packages/pylint/utils.py", line 1305, in walk
    cb(astroid)
  File "/home/vsts/work/1/s/.tox/py36/lib/python3.6/site-packages/pylint/checkers/imports.py", line 507, in leave_module
    std_imports, ext_imports, loc_imports = self._check_imports_order(node)
  File "/home/vsts/work/1/s/.tox/py36/lib/python3.6/site-packages/pylint/checkers/imports.py", line 664, in _check_imports_order
    isort_obj = isort.SortImports(
AttributeError: module 'isort' has no attribute 'SortImports'
ERROR: InvocationError for command /home/vsts/work/1/s/.tox/py36/bin/pylint knack --rcfile=.pylintrc -r n -d I0013 (exited with code 1)
```

Updating Pylint so that `isort` is pinned (https://github.com/PyCQA/pylint/pull/2773).