### PR TITLE
[Config] Make config items case-insensitive

### DIFF
--- a/knack/config.py
+++ b/knack/config.py
@@ -111,12 +111,12 @@ class CLIConfig(object):
         import re
         pattern = self.env_var_name(section, '.+')
         candidates = [(k.split('_')[-1], os.environ[k], k) for k in os.environ if re.match(pattern, k)]
-        result = {c[0]: c for c in candidates}
+        result = {c[0].lower(): c for c in candidates}
         for config in self._config_file_chain if self.use_local_config else self._config_file_chain[-1:]:
             try:
                 entries = config.items(section)
                 for name, value in entries:
-                    if name not in result:
+                    if name.lower() not in result:
                         result[name] = (name, value, config.config_path)
             except (configparser.NoSectionError, configparser.NoOptionError):
                 pass

--- a/knack/config.py
+++ b/knack/config.py
@@ -109,14 +109,14 @@ class CLIConfig(object):
 
     def items(self, section):
         import re
-        pattern = self.env_var_name(section, '.+')
+        pattern = self.env_var_name(section, '[0-9A-Z]+')
         candidates = [(k.split('_')[-1], os.environ[k], k) for k in os.environ if re.match(pattern, k)]
         result = {c[0].lower(): c for c in candidates}
         for config in self._config_file_chain if self.use_local_config else self._config_file_chain[-1:]:
             try:
                 entries = config.items(section)
                 for name, value in entries:
-                    if name.lower() not in result:
+                    if name not in result:
                         result[name] = (name, value, config.config_path)
             except (configparser.NoSectionError, configparser.NoOptionError):
                 pass

--- a/knack/config.py
+++ b/knack/config.py
@@ -109,8 +109,8 @@ class CLIConfig(object):
 
     def items(self, section):
         import re
-        pattern = self.env_var_name(section, '[0-9A-Z]+')
-        candidates = [(k.split('_')[-1], os.environ[k], k) for k in os.environ if re.match(pattern, k)]
+        pattern = self.env_var_name(section, '[0-9A-Z][0-9A-Z_]*')
+        candidates = [(k.replace(self.env_var_name(section, ''), ''), os.environ[k], k) for k in os.environ if re.match(pattern, k)]
         result = {c[0].lower(): c for c in candidates}
         for config in self._config_file_chain if self.use_local_config else self._config_file_chain[-1:]:
             try:

--- a/knack/config.py
+++ b/knack/config.py
@@ -109,9 +109,18 @@ class CLIConfig(object):
 
     def items(self, section):
         import re
-        pattern = self.env_var_name(section, '[0-9A-Z][0-9A-Z_]*')
-        candidates = [(k.replace(self.env_var_name(section, ''), ''), os.environ[k], k) for k in os.environ if re.match(pattern, k)]
-        result = {c[0].lower(): c for c in candidates}
+        pattern = self.env_var_name(section, '([0-9A-Z][0-9A-Z_]*)')
+        env_entries = []
+        for k in os.environ:
+            matched = re.match(pattern, k)
+            if matched:
+                # (name, value, ENV_VAR_NAME)
+                item = (matched.group(1).lower(), os.environ[k], k)
+                env_entries.append(item)
+
+        # Prepare result with env entries first
+        result = {c[0]: c for c in env_entries}
+        # Add entries from config files if they do not exist yet
         for config in self._config_file_chain if self.use_local_config else self._config_file_chain[-1:]:
             try:
                 entries = config.items(section)

--- a/knack/config.py
+++ b/knack/config.py
@@ -109,10 +109,12 @@ class CLIConfig(object):
 
     def items(self, section):
         import re
-        pattern = self.env_var_name(section, '([0-9A-Z][0-9A-Z_]*)')
+        # Only allow valid env vars, in all caps: CLI_SECTION_TEST_OPTION, CLI_SECTION__TEST_OPTION
+        pattern = self.env_var_name(section, '([0-9A-Z_]+)')
         env_entries = []
         for k in os.environ:
-            matched = re.match(pattern, k)
+            # Must be a full match, otherwise CLI_SECTION_T part in CLI_MYSECTION_Test_Option will match
+            matched = re.fullmatch(pattern, k)
             if matched:
                 # (name, value, ENV_VAR_NAME)
                 item = (matched.group(1).lower(), os.environ[k], k)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,15 +171,21 @@ class TestCLIConfig(unittest.TestCase):
 
     def test_items_case_insensitive(self):
         section = 'MySection'
+
         self.cli_config.set_value(section, 'option', 'value')
         self.cli_config.set_to_use_local_config(True)
         self.cli_config.set_value(section, 'Option', 'localValue')
         items_result = self.cli_config.items(section)
+        # The items function is expected to
+        # return local config instead of returning both local config 'Option' and global config 'option'
         self.assertEqual(len(items_result), 1)
         self.assertEqual(items_result[0]['value'], 'localValue')
 
         with mock.patch.dict('os.environ', {self.cli_config.env_var_name(section, 'OPTION'): 'envValue'}):
             items_result = self.cli_config.items(section)
+            # The items function is expected to
+            # return environment setting instead of
+            # returning both local config 'Option' and environment variable 'OPTION'
             self.assertEqual(len(items_result), 1)
             self.assertEqual(items_result[0]['value'], 'envValue')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,14 +215,12 @@ class TestCLIConfig(unittest.TestCase):
         # Windows' env var is case-insensitive, so skip
         import platform
         if platform.system() != 'Windows':
-            file_value = 'file_value'
-
             # Not shown
             with mock.patch.dict('os.environ', {'CLI_MYSECTION_Test_Option': env_value}):
                 items_result = self.cli_config.items(file_section)
                 self.assertEqual(len(items_result), 0)
 
-            # Not overridden
+            # No overriding
             self.cli_config.set_value(file_section, 'test_option', file_value)
             with mock.patch.dict('os.environ', {'CLI_MYSECTION_Test_Option': env_value}):
                 items_result = self.cli_config.items(file_section)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,6 +169,20 @@ class TestCLIConfig(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.cli_config.getboolean(section, option)
 
+    def test_items_case_insensitive(self):
+        section = 'MySection'
+        self.cli_config.set_value(section, 'option', 'value')
+        self.cli_config.set_to_use_local_config(True)
+        self.cli_config.set_value(section, 'Option', 'localValue')
+        items_result = self.cli_config.items(section)
+        self.assertEqual(len(items_result), 1)
+        self.assertEqual(items_result[0]['value'], 'localValue')
+
+        with mock.patch.dict('os.environ', {self.cli_config.env_var_name(section, 'OPTION'): 'envValue'}):
+            items_result = self.cli_config.items(section)
+            self.assertEqual(len(items_result), 1)
+            self.assertEqual(items_result[0]['value'], 'envValue')
+
     def test_set_config_value(self):
         self.cli_config.set_value('test_section', 'test_option', 'a_value')
         config = configparser.ConfigParser()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -170,18 +170,14 @@ class TestCLIConfig(unittest.TestCase):
             self.cli_config.getboolean(section, option)
 
     def test_items_case_insensitive(self):
-        section = 'MySection'
+        section = 'MYSECTION'
+        envOption = '{}_{}_{}'.format(CLIConfig._DEFAULT_CONFIG_ENV_VAR_PREFIX, section, 'OPTION')
+        envVaule = 'envValue'
+        configOption = 'option'
+        configValue = 'value'
 
-        self.cli_config.set_value(section, 'option', 'value')
-        self.cli_config.set_to_use_local_config(True)
-        self.cli_config.set_value(section, 'Option', 'localValue')
-        items_result = self.cli_config.items(section)
-        # The items function is expected to
-        # return local config instead of returning both local config 'Option' and global config 'option'
-        self.assertEqual(len(items_result), 1)
-        self.assertEqual(items_result[0]['value'], 'localValue')
-
-        with mock.patch.dict('os.environ', {self.cli_config.env_var_name(section, 'OPTION'): 'envValue'}):
+        with mock.patch.dict('os.environ', {envOption: envVaule}):
+            self.cli_config.set_value(section, configOption, configValue)
             items_result = self.cli_config.items(section)
             # The items function is expected to
             # return environment setting instead of

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,9 +171,9 @@ class TestCLIConfig(unittest.TestCase):
 
     def test_items_case_insensitive(self):
         section = 'MYSECTION'
-        envOption = '{}_{}_{}'.format(CLIConfig._DEFAULT_CONFIG_ENV_VAR_PREFIX, section, 'OPTION')
+        envOption = '{}_{}_{}'.format(CLIConfig._DEFAULT_CONFIG_ENV_VAR_PREFIX, section, 'TEST_OPTION')
         envVaule = 'envValue'
-        configOption = 'option'
+        configOption = 'test_option'
         configValue = 'value'
 
         with mock.patch.dict('os.environ', {envOption: envVaule}):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,21 +169,65 @@ class TestCLIConfig(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.cli_config.getboolean(section, option)
 
-    def test_items_case_insensitive(self):
-        section = 'MYSECTION'
-        envOption = '{}_{}_{}'.format(CLIConfig._DEFAULT_CONFIG_ENV_VAR_PREFIX, section, 'TEST_OPTION')
-        envVaule = 'envValue'
-        configOption = 'test_option'
-        configValue = 'value'
+    def test_items(self):
+        file_section = "MySection"
+        file_value = 'file_value'
+        env_value = 'env_value'
 
-        with mock.patch.dict('os.environ', {envOption: envVaule}):
-            self.cli_config.set_value(section, configOption, configValue)
-            items_result = self.cli_config.items(section)
-            # The items function is expected to
-            # return environment setting instead of
-            # returning both local config 'Option' and environment variable 'OPTION'
+        # Test file-only options are listed
+        file_only_option = 'file_only_option'
+        self.cli_config.set_value(file_section, file_only_option, file_value)
+        items_result = self.cli_config.items(file_section)
+        self.assertEqual(len(items_result), 1)
+        self.assertEqual(items_result[0]['name'], file_only_option)
+        self.assertEqual(items_result[0]['value'], file_value)
+        self.cli_config.remove_option(file_section, file_only_option)
+
+        # Test env-only options are listed
+        with mock.patch.dict('os.environ', {'CLI_MYSECTION_ENV_ONLY_OPTION': env_value}):
+            items_result = self.cli_config.items(file_section)
             self.assertEqual(len(items_result), 1)
-            self.assertEqual(items_result[0]['value'], 'envValue')
+            self.assertEqual(items_result[0]['name'], 'env_only_option')
+            self.assertEqual(items_result[0]['value'], env_value)
+
+        # Test file options are overridden by env options, for both single-word and multi-word options
+        test_options = [
+            # file_option, file_value, env_name, env_value
+            # Test single-word option
+            ('optionsingle', 'file_value_single', 'CLI_MYSECTION_OPTIONSINGLE', 'env_value_single'),
+            # Test multi-word option
+            ('option_multiple', 'file_value_multiple', 'CLI_MYSECTION_OPTION_MULTIPLE', 'env_value_multiple')
+        ]
+        for file_option, file_value, env_name, env_value in test_options:
+            self.cli_config.set_value(file_section, file_option, file_value)
+            items_result = self.cli_config.items(file_section)
+            self.assertEqual(len(items_result), 1)
+            self.assertEqual(items_result[0]['value'], file_value)
+
+            with mock.patch.dict('os.environ', {env_name: env_value}):
+                items_result = self.cli_config.items(file_section)
+                self.assertEqual(len(items_result), 1)
+                self.assertEqual(items_result[0]['value'], env_value)
+
+            self.cli_config.remove_option(file_section, file_option)
+
+        # Test Invalid_Env_Var is not accepted on Linux
+        # Windows' env var is case-insensitive, so skip
+        import platform
+        if platform.system() != 'Windows':
+            file_value = 'file_value'
+
+            # Not shown
+            with mock.patch.dict('os.environ', {'CLI_MYSECTION_Test_Option': env_value}):
+                items_result = self.cli_config.items(file_section)
+                self.assertEqual(len(items_result), 0)
+
+            # Not overridden
+            self.cli_config.set_value(file_section, 'test_option', file_value)
+            with mock.patch.dict('os.environ', {'CLI_MYSECTION_Test_Option': env_value}):
+                items_result = self.cli_config.items(file_section)
+                self.assertEqual(len(items_result), 1)
+                self.assertEqual(items_result[0]['value'], file_value)
 
     def test_set_config_value(self):
         self.cli_config.set_value('test_section', 'test_option', 'a_value')


### PR DESCRIPTION
## Description
Fix https://github.com/Azure/azure-cli/issues/14397: az configure --list-defaults should not be case sensitive for environment variables

## Testing Guide
preparation(need Azure CLI in advance)
```sh
az configure --defaults location=eastus
export AZURE_DEFAULTS_LOCATION=eastasia
```
test
```sh
az configure --list-defaults
```

results before
```
[
  {
    "name": "LOCATION",
    "source": "AZURE_DEFAULTS_LOCATION",
    "value": "eastasia"
  },
  {
    "name": "location",
    "source": "C:\\Users\\yishiwang\\.azure\\config",
    "value": "eastus"
  }
]
```

results after
```
[
  {
    "name": "LOCATION",
    "source": "AZURE_DEFAULTS_LOCATION",
    "value": "eastasia"
  }
]
```