### PR TITLE
[Log] Print INFO log from SDK

### DIFF
--- a/knack/log.py
+++ b/knack/log.py
@@ -117,7 +117,7 @@ class CLILogging(object):  # pylint: disable=too-many-instance-attributes
         self.cli_ctx = cli_ctx
         self.cli_ctx.register_event(EVENT_PARSER_GLOBAL_CREATE, CLILogging.on_global_arguments)
 
-        # These attributes' value are determined when `configure` is called
+        # The value is determined when `configure` is called
         self.log_level = None
 
     def configure(self, args):

--- a/knack/log.py
+++ b/knack/log.py
@@ -227,7 +227,7 @@ class CLILogging(object):  # pylint: disable=too-many-instance-attributes
             Show the level name if coloring is disabled (e.g. INFO).
             Also, root logger should always show the logger name.
         """
-        if self.log_level == CliLogLevel.ERROR:
+        if self.log_level == CliLogLevel.DEBUG:
             # If --debug flag is specified, show the logger name as well
             cli_logger_format = {
                 True: '%(name)s: %(message)s',

--- a/knack/log.py
+++ b/knack/log.py
@@ -119,8 +119,8 @@ class CLILogging(object):  # pylint: disable=too-many-instance-attributes
 
         # These attributes' value are determined when `configure` is called
         self.log_level = None
-        self.console_log_configs = None
-        self.console_log_format = None
+        self._console_log_configs = None
+        self._console_log_format = None
 
     def configure(self, args):
         """ Configure the loggers with the appropriate log level etc.
@@ -129,9 +129,9 @@ class CLILogging(object):  # pylint: disable=too-many-instance-attributes
         :type args: list
         """
         self.log_level = self._determine_log_level(args)
-        self.console_log_configs = self._get_console_log_configs()
-        self.console_log_format = self._get_console_log_format()
-        log_level_config = self.console_log_configs[self.log_level]
+        self._console_log_configs = self._get_console_log_configs()
+        self._console_log_format = self._get_console_log_format()
+        log_level_config = self._console_log_configs[self.log_level]
         root_logger = logging.getLogger()
         cli_logger = logging.getLogger(self._cli_logger_name)
         # Set the levels of the loggers to lowest level.
@@ -168,10 +168,10 @@ class CLILogging(object):  # pylint: disable=too-many-instance-attributes
 
     def _init_console_handlers(self, root_logger, cli_logger, log_level_config):
         root_logger.addHandler(_CustomStreamHandler(log_level_config['root'],
-                                                    self.console_log_format['root'],
+                                                    self._console_log_format['root'],
                                                     self.cli_ctx.enable_color))
         cli_logger.addHandler(_CustomStreamHandler(log_level_config[self._cli_logger_name],
-                                                   self.console_log_format[self._cli_logger_name],
+                                                   self._console_log_format[self._cli_logger_name],
                                                    self.cli_ctx.enable_color))
 
     def _init_logfile_handlers(self, root_logger, cli_logger):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -35,7 +35,7 @@ class TestLoggingEventHandling(unittest.TestCase):
                                                            help=mock.ANY)
 
 
-class TestLoggingLevel(unittest.TestCase):
+class TestCLILogging(unittest.TestCase):
     def setUp(self):
         self.mock_ctx = MockContext()
         self.cli_logging = CLILogging('clitest', cli_ctx=self.mock_ctx)
@@ -104,6 +104,66 @@ class TestLoggingLevel(unittest.TestCase):
         self.assertEqual(module_logger.name, 'a.module')
         module_logger = get_logger()
         self.assertEqual(module_logger.name, 'knack')
+
+    def test_get_console_log_levels(self):
+        # CRITICAL
+        self.cli_logging.log_level = 0
+        levels = self.cli_logging._get_console_log_levels()
+        expected = {'knack': 50, 'root': 50}
+        self.assertEqual(levels, expected)
+
+        # ERROR
+        self.cli_logging.log_level = 1
+        levels = self.cli_logging._get_console_log_levels()
+        expected = {'knack': 40, 'root': 50}
+        self.assertEqual(levels, expected)
+
+        # WARNING
+        self.cli_logging.log_level = 2
+        levels = self.cli_logging._get_console_log_levels()
+        expected = {'knack': 30, 'root': 50}
+        self.assertEqual(levels, expected)
+
+        # INFO
+        self.cli_logging.log_level = 3
+        levels = self.cli_logging._get_console_log_levels()
+        expected = {'knack': 20, 'root': 50}
+        self.assertEqual(levels, expected)
+
+        # DEBUG
+        self.cli_logging.log_level = 4
+        levels = self.cli_logging._get_console_log_levels()
+        expected = {'knack': 10, 'root': 10}
+        self.assertEqual(levels, expected)
+
+    def test_get_console_log_formats(self):
+        # DEBUG level, color enabled
+        self.cli_logging.log_level = 4
+        self.cli_logging.cli_ctx.enable_color = True
+        formats = self.cli_logging._get_console_log_formats()
+        expected = {'knack': '%(name)s: %(message)s', 'root': '%(name)s: %(message)s'}
+        self.assertEqual(formats, expected)
+
+        # DEBUG level, color disabled
+        self.cli_logging.log_level = 4
+        self.cli_logging.cli_ctx.enable_color = False
+        formats = self.cli_logging._get_console_log_formats()
+        expected = {'knack': '%(levelname)s: %(name)s: %(message)s', 'root': '%(levelname)s: %(name)s: %(message)s'}
+        self.assertEqual(formats, expected)
+
+        # WARNING level, color enabled
+        self.cli_logging.log_level = 2
+        self.cli_logging.cli_ctx.enable_color = True
+        formats = self.cli_logging._get_console_log_formats()
+        expected = {'knack': '%(message)s', 'root': '%(message)s'}
+        self.assertEqual(formats, expected)
+
+        # WARNING level, color disabled
+        self.cli_logging.log_level = 2
+        self.cli_logging.cli_ctx.enable_color = False
+        formats = self.cli_logging._get_console_log_formats()
+        expected = {'knack': '%(levelname)s: %(message)s', 'root': '%(levelname)s: %(message)s'}
+        self.assertEqual(formats, expected)
 
 
 class TestCustomStreamHandler(unittest.TestCase):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -101,7 +101,9 @@ class TestLoggingLevel(unittest.TestCase):
 
     def test_get_module_logger(self):
         module_logger = get_logger('a.module')
-        self.assertEqual(module_logger.name, 'cli.a.module')
+        self.assertEqual(module_logger.name, 'a.module')
+        module_logger = get_logger()
+        self.assertEqual(module_logger.name, 'cli')
 
 
 class TestCustomStreamHandler(unittest.TestCase):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -103,7 +103,7 @@ class TestLoggingLevel(unittest.TestCase):
         module_logger = get_logger('a.module')
         self.assertEqual(module_logger.name, 'a.module')
         module_logger = get_logger()
-        self.assertEqual(module_logger.name, 'cli')
+        self.assertEqual(module_logger.name, 'knack')
 
 
 class TestCustomStreamHandler(unittest.TestCase):


### PR DESCRIPTION
1. Previously in `get_logger`, logger name is the module name prefixed with `CLI_LOGGER_NAME`, like `cli.azure.cli.core`. Now it only takes the module name, like `azure.cli.core`, to be in sync with the Python SDK's logger name `azure.*`.

2. Make `cli_logger_name` customizable, so that all `INFO` logs under `azure.*` loggers can be printed, like

   - `azure.core.pipeline.policies.http_logging_policy`
   - `azure.cli.core`

3. Previously, logger `cli.azure.cli.core`'s logger name is not printed:
   ```
   Modules found from index for 'group': ['azure.cli.command_modules.resource']
   Loading command modules:
   Name                  Load Time    Groups  Commands
   resource                  0.009        35       164
   Total (1)                 0.009        35       164
   ```
   
   Now the logger name is printed even for CLI logger when `--debug` is specified, so that the log source can be better distinguished.

ℹ As before, `DEBUG` log from both CLI and underlying libs will be printed, so this won't affect `DEBUG` log.

Example:

```log
> az group show -n fy --debug
DEBUG: knack.log: File logging enabled - writing logs to 'C:\Users\jiasli\.azure\logs'.
DEBUG: knack.cli: Command arguments: ['group', 'show', '-n', 'fy', '--debug']
DEBUG: knack.cli: Event: Cli.PreExecute []
...
DEBUG: azure.cli.core: Modules found from index for 'group': ['azure.cli.command_modules.resource']
DEBUG: azure.cli.core: Loading command modules:
DEBUG: azure.cli.core: Name                  Load Time    Groups  Commands
DEBUG: azure.cli.core: resource                  0.009        35       164
DEBUG: azure.cli.core: Total (1)                 0.009        35       164
...
DEBUG: azure.cli.core._profile: Retrieving token from ADAL for resource 'https://management.core.windows.net/'
...
DEBUG: azure.core.pipeline.policies._universal: Request URL: 'https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/fy?api-version=2020-06-01'
DEBUG: azure.core.pipeline.policies._universal: Request method: 'GET'
DEBUG: azure.core.pipeline.policies._universal: Request headers:
DEBUG: azure.core.pipeline.policies._universal:     'Accept': 'application/json'
...
INFO: azure.core.pipeline.policies.http_logging_policy: Request URL: 'https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/fy?api-version=REDACTED'
INFO: azure.core.pipeline.policies.http_logging_policy: Request method: 'GET'
INFO: azure.core.pipeline.policies.http_logging_policy: Request headers:
INFO: azure.core.pipeline.policies.http_logging_policy:     'Accept': 'application/json'
INFO: azure.core.pipeline.policies.http_logging_policy:     'x-ms-client-request-id': 'd8fa889e-1822-11eb-b2f8-84a93e63aa78'
...

> az group show -n fy --verbose
...
INFO: azure.core.pipeline.policies.http_logging_policy: Request URL: 'https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/fy?api-version=REDACTED'
INFO: azure.core.pipeline.policies.http_logging_policy: Request method: 'GET'
INFO: azure.core.pipeline.policies.http_logging_policy: Request headers:
INFO: azure.core.pipeline.policies.http_logging_policy:     'Accept': 'application/json'
INFO: azure.core.pipeline.policies.http_logging_policy:     'x-ms-client-request-id': 'd8fa889e-1822-11eb-b2f8-84a93e63aa78'
...
```
