### PR TITLE
[Tag] Allow customizing tag message

### DIFF
--- a/knack/arguments.py
+++ b/knack/arguments.py
@@ -10,7 +10,7 @@ from .deprecation import Deprecated
 from .preview import PreviewItem
 from .experimental import ExperimentalItem
 from .log import get_logger
-from .util import CLIError
+from .util import CLIError, status_tag_messages
 
 
 logger = get_logger(__name__)
@@ -250,8 +250,9 @@ class ArgumentsContext(object):
             return PreviewArgumentAction
 
         def _get_preview_arg_message(self):
-            return "{} '{}' is in preview. It may be changed/removed in a future release.".format(
-                self.object_type.capitalize(), self.target)
+            # "Argument xxx"
+            subject = "{} '{}'".format(self.object_type.capitalize(), self.target)
+            return status_tag_messages['preview'].format(subject)
 
         options_list = kwargs.get('options_list', None)
         object_type = 'argument'
@@ -300,8 +301,9 @@ class ArgumentsContext(object):
             return ExperimentalArgumentAction
 
         def _get_experimental_arg_message(self):
-            return "{} '{}' is experimental and not covered by customer support. " \
-                   "Please use with discretion.".format(self.object_type.capitalize(), self.target)
+            # "Argument xxx"
+            subject = "{} '{}'".format(self.object_type.capitalize(), self.target)
+            return status_tag_messages['experimental'].format(subject)
 
         options_list = kwargs.get('options_list', None)
         object_type = 'argument'

--- a/knack/experimental.py
+++ b/knack/experimental.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from .util import StatusTag
+from .util import StatusTag, status_tag_messages
 
 _EXPERIMENTAL_TAG = '[Experimental]'
 _experimental_kwarg = 'experimental_info'
@@ -50,8 +50,7 @@ class ExperimentalItem(StatusTag):
         """
 
         def _default_get_message(self):
-            return "This {} is experimental and not covered by customer support. " \
-                   "Please use with discretion.".format(self.object_type)
+            return status_tag_messages['experimental'].format("This " + self.object_type)
 
         super(ExperimentalItem, self).__init__(
             cli_ctx=cli_ctx,
@@ -68,8 +67,7 @@ class ImplicitExperimentalItem(ExperimentalItem):
     def __init__(self, **kwargs):
 
         def get_implicit_experimental_message(self):
-            return "Command group '{}' is experimental and not covered by customer support. " \
-                   "Please use with discretion.".format(self.target)
+            return status_tag_messages['experimental'].format("Command group '{}'".format(self.target))
 
         kwargs.update({
             'tag_func': lambda _: '',

--- a/knack/preview.py
+++ b/knack/preview.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from .util import StatusTag
+from .util import StatusTag, status_tag_messages
 
 _PREVIEW_TAG = '[Preview]'
 _preview_kwarg = 'preview_info'
@@ -50,7 +50,7 @@ class PreviewItem(StatusTag):
         """
 
         def _default_get_message(self):
-            return "This {} is in preview. It may be changed/removed in a future release.".format(self.object_type)
+            return status_tag_messages['preview'].format("This " + self.object_type)
 
         super(PreviewItem, self).__init__(
             cli_ctx=cli_ctx,
@@ -67,8 +67,7 @@ class ImplicitPreviewItem(PreviewItem):
     def __init__(self, **kwargs):
 
         def get_implicit_preview_message(self):
-            return "Command group '{}' is in preview. It may be changed/removed " \
-                   "in a future release.".format(self.target)
+            return status_tag_messages['preview'].format("Command group '{}'".format(self.target))
 
         kwargs.update({
             'tag_func': lambda _: '',

--- a/knack/util.py
+++ b/knack/util.py
@@ -11,6 +11,14 @@ from enum import Enum
 
 NO_COLOR_VARIABLE_NAME = 'KNACK_NO_COLOR'
 
+# Override these values to customize the status message.
+# The message should contain a placeholder indicating the subject (like 'This command group', 'Commend group xxx').
+# (A dict is used to avoid the "from A import B" pitfall that creates a copy of the imported B.)
+status_tag_messages = {
+    'preview': "{} is in preview. It may be changed/removed in a future release.",
+    'experimental': "{} is experimental and under development."
+}
+
 
 class CommandResultItem(object):  # pylint: disable=too-few-public-methods
     def __init__(self, result, table_transformer=None, is_query_active=False,

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -65,8 +65,7 @@ class TestCommandExperimental(unittest.TestCase):
         """ Ensure general warning displayed when running command from an experimental parent group. """
         self.cli_ctx.invoke('grp1 cmd1 -b b'.split())
         actual = self.io.getvalue()
-        expected = "Command group 'grp1' is experimental and not covered by customer support. " \
-                   "Please use with discretion."
+        expected = "Command group 'grp1' is experimental and under development."
         self.assertIn(remove_space(expected), remove_space(actual))
 
     @redirect_io
@@ -93,7 +92,7 @@ Commands:
         """ Ensure general warning displayed when running experimental command. """
         self.cli_ctx.invoke('cmd1 -b b'.split())
         actual = self.io.getvalue()
-        expected = "This command is experimental and not covered by customer support. Please use with discretion."
+        expected = "This command is experimental and under development."
         self.assertIn(remove_space(expected), remove_space(actual))
 
 
@@ -134,7 +133,7 @@ class TestCommandGroupExperimental(unittest.TestCase):
         expected = """
 Group
     cli group1 : A group.
-        This command group is experimental and not covered by customer support. Please use with discretion.
+        This command group is experimental and under development.
 Commands:
     cmd1 : Short summary here.
 
@@ -151,7 +150,7 @@ Commands:
 Command
     {} group1 cmd1 : Short summary here.
         Long summary here. Still long summary.
-        Command group 'group1' is experimental and not covered by customer support. Please use with discretion.
+        Command group 'group1' is experimental and under development.
 """.format(self.cli_ctx.name)
         self.assertIn(remove_space(expected), remove_space(actual))
 
@@ -194,7 +193,7 @@ class TestArgumentExperimental(unittest.TestCase):
         expected = """
 Arguments
     --arg1 [Experimental] [Required] : Arg1.
-        Argument '--arg1' is experimental and not covered by customer support. Please use with discretion.
+        Argument '--arg1' is experimental and under development.
 """.format(self.cli_ctx.name)
         self.assertIn(remove_space(expected), remove_space(actual))
 
@@ -203,8 +202,7 @@ Arguments
         """ Ensure deprecated arguments can be used. """
         self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar'.split())
         actual = self.io.getvalue()
-        experimental_expected = "Argument '--arg1' is experimental and not covered by customer support. " \
-                                "Please use with discretion."
+        experimental_expected = "Argument '--arg1' is experimental and under development."
         self.assertIn(experimental_expected, actual)
 
         action_expected = "Side-effect from some original action!"


### PR DESCRIPTION
A singleton dict `status_tag_messages` is used to hold configurable `StatusTag` messages. Developers can override the content of `status_tag_messages` to customize the help and warning messages.