### PR TITLE
[Event] Add EVENT_CLI_SUCCESSFUL_EXECUTE

### DIFF
--- a/knack/cli.py
+++ b/knack/cli.py
@@ -15,7 +15,7 @@ from .log import CLILogging, get_logger
 from .util import CLIError
 from .config import CLIConfig
 from .query import CLIQuery
-from .events import EVENT_CLI_PRE_EXECUTE, EVENT_CLI_POST_EXECUTE
+from .events import EVENT_CLI_PRE_EXECUTE, EVENT_CLI_SUCCESSFUL_EXECUTE, EVENT_CLI_POST_EXECUTE
 from .parser import CLICommandParser
 from .commands import CLICommandsLoader
 from .help import CLIHelp
@@ -219,6 +219,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
                 if cmd_result and cmd_result.result is not None:
                     formatter = self.output.get_formatter(output_type)
                     self.output.out(cmd_result, formatter=formatter, out_file=out_file)
+            self.raise_event(EVENT_CLI_SUCCESSFUL_EXECUTE)
         except KeyboardInterrupt as ex:
             exit_code = 1
             self.result = CommandResultItem(None, error=ex, exit_code=exit_code)

--- a/knack/cli.py
+++ b/knack/cli.py
@@ -219,7 +219,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
                 if cmd_result and cmd_result.result is not None:
                     formatter = self.output.get_formatter(output_type)
                     self.output.out(cmd_result, formatter=formatter, out_file=out_file)
-            self.raise_event(EVENT_CLI_SUCCESSFUL_EXECUTE)
+                self.raise_event(EVENT_CLI_SUCCESSFUL_EXECUTE, result=cmd_result.result)
         except KeyboardInterrupt as ex:
             exit_code = 1
             self.result = CommandResultItem(None, error=ex, exit_code=exit_code)

--- a/knack/events.py
+++ b/knack/events.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 EVENT_CLI_PRE_EXECUTE = 'Cli.PreExecute'
+EVENT_CLI_SUCCESSFUL_EXECUTE = 'Cli.SuccessfulExecute'
 EVENT_CLI_POST_EXECUTE = 'Cli.PostExecute'
 
 EVENT_INVOKER_PRE_CMD_TBL_CREATE = 'CommandInvoker.OnPreCommandTableCreate'


### PR DESCRIPTION
## Context

In the current implementation, the command handler is invoked at `L215`:

https://github.com/microsoft/knack/blob/0d0308bc567f2d25654bb39201c02ab262d7ce0a/knack/cli.py#L215

The JSON is printed at `L221`:

https://github.com/microsoft/knack/blob/8b3757ddff6b63bf4789c8736a506e1754f1f92b/knack/cli.py#L221

Therefore, anything printed by the command handler will be shown **before** the JSON output.

## Change

Add a new event `EVENT_CLI_SUCCESSFUL_EXECUTE`. It is raised after a command is successfully executed, allowing a callback `func` to be registered and called after JSON is printed. 

This enables post-output hint to be displayed **after** the JSON output. 
