### PR TITLE
[Log] Support multiple CLI loggers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.8.0rc2
+++++++++
+
+* Support multiple cli loggers by adding more logger names to `knack.log.cli_logger_names` list (#227)
+
 0.8.0rc1
 ++++++++
 * Make config item names case-insensitive (#220)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = '0.8.0rc1'
+VERSION = '0.8.0rc2'
 
 DEPENDENCIES = [
     'argcomplete',

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -101,39 +101,37 @@ class TestCLILogging(unittest.TestCase):
 
     def test_get_module_logger(self):
         module_logger = get_logger('a.module')
-        self.assertEqual(module_logger.name, 'a.module')
-        module_logger = get_logger()
-        self.assertEqual(module_logger.name, 'knack')
+        self.assertEqual(module_logger.name, 'cli.a.module')
 
     def test_get_console_log_levels(self):
         # CRITICAL
         self.cli_logging.log_level = 0
         levels = self.cli_logging._get_console_log_levels()
-        expected = {'knack': 50, 'root': 50}
+        expected = {'cli': 50, 'root': 50}
         self.assertEqual(levels, expected)
 
         # ERROR
         self.cli_logging.log_level = 1
         levels = self.cli_logging._get_console_log_levels()
-        expected = {'knack': 40, 'root': 50}
+        expected = {'cli': 40, 'root': 50}
         self.assertEqual(levels, expected)
 
         # WARNING
         self.cli_logging.log_level = 2
         levels = self.cli_logging._get_console_log_levels()
-        expected = {'knack': 30, 'root': 50}
+        expected = {'cli': 30, 'root': 50}
         self.assertEqual(levels, expected)
 
         # INFO
         self.cli_logging.log_level = 3
         levels = self.cli_logging._get_console_log_levels()
-        expected = {'knack': 20, 'root': 50}
+        expected = {'cli': 20, 'root': 50}
         self.assertEqual(levels, expected)
 
         # DEBUG
         self.cli_logging.log_level = 4
         levels = self.cli_logging._get_console_log_levels()
-        expected = {'knack': 10, 'root': 10}
+        expected = {'cli': 10, 'root': 10}
         self.assertEqual(levels, expected)
 
     def test_get_console_log_formats(self):
@@ -141,28 +139,28 @@ class TestCLILogging(unittest.TestCase):
         self.cli_logging.log_level = 4
         self.cli_logging.cli_ctx.enable_color = True
         formats = self.cli_logging._get_console_log_formats()
-        expected = {'knack': '%(name)s: %(message)s', 'root': '%(name)s: %(message)s'}
+        expected = {'cli': '%(name)s: %(message)s', 'root': '%(name)s: %(message)s'}
         self.assertEqual(formats, expected)
 
         # DEBUG level, color disabled
         self.cli_logging.log_level = 4
         self.cli_logging.cli_ctx.enable_color = False
         formats = self.cli_logging._get_console_log_formats()
-        expected = {'knack': '%(levelname)s: %(name)s: %(message)s', 'root': '%(levelname)s: %(name)s: %(message)s'}
+        expected = {'cli': '%(levelname)s: %(name)s: %(message)s', 'root': '%(levelname)s: %(name)s: %(message)s'}
         self.assertEqual(formats, expected)
 
         # WARNING level, color enabled
         self.cli_logging.log_level = 2
         self.cli_logging.cli_ctx.enable_color = True
         formats = self.cli_logging._get_console_log_formats()
-        expected = {'knack': '%(message)s', 'root': '%(message)s'}
+        expected = {'cli': '%(message)s', 'root': '%(message)s'}
         self.assertEqual(formats, expected)
 
         # WARNING level, color disabled
         self.cli_logging.log_level = 2
         self.cli_logging.cli_ctx.enable_color = False
         formats = self.cli_logging._get_console_log_formats()
-        expected = {'knack': '%(levelname)s: %(message)s', 'root': '%(levelname)s: %(message)s'}
+        expected = {'cli': '%(levelname)s: %(message)s', 'root': '%(levelname)s: %(message)s'}
         self.assertEqual(formats, expected)
 
 


### PR DESCRIPTION
Redo https://github.com/microsoft/knack/pull/221 
1. Revert `cli_logger_name` of `knack.log.CLILogging.__init__` so that no breaking change is made.
2. Support multiple cli loggers by adding more logger names to `knack.log.cli_logger_names` list.