### PR TITLE
Bump pylint and flake8

### DIFF
--- a/knack/arguments.py
+++ b/knack/arguments.py
@@ -83,7 +83,7 @@ class CLICommandArgument(object):
 
     def __setattr__(self, name, value):  # pylint: disable=inconsistent-return-statements
         if name == 'type':
-            return super(CLICommandArgument, self).__setattr__(name, value)
+            return super().__setattr__(name, value)
         self.type.settings[name] = value
 
 
@@ -186,7 +186,7 @@ class ArgumentsContext(object):
                     else:
                         namespace._argument_deprecations.append(deprecate_info)  # pylint: disable=protected-access
                     try:
-                        super(DeprecatedArgumentAction, self).__call__(parser, namespace, values, option_string)
+                        super().__call__(parser, namespace, values, option_string)
                     except NotImplementedError:
                         setattr(namespace, self.dest, values)
 
@@ -209,7 +209,7 @@ class ArgumentsContext(object):
                         else:
                             namespace._argument_deprecations.append(deprecated_opt)  # pylint: disable=protected-access
                     try:
-                        super(DeprecatedOptionAction, self).__call__(parser, namespace, values, option_string)
+                        super().__call__(parser, namespace, values, option_string)
                     except NotImplementedError:
                         setattr(namespace, self.dest, values)
 
@@ -243,7 +243,7 @@ class ArgumentsContext(object):
                     else:
                         namespace._argument_previews.append(preview_info)  # pylint: disable=protected-access
                     try:
-                        super(PreviewArgumentAction, self).__call__(parser, namespace, values, option_string)
+                        super().__call__(parser, namespace, values, option_string)
                     except NotImplementedError:
                         setattr(namespace, self.dest, values)
 
@@ -294,7 +294,7 @@ class ArgumentsContext(object):
                     else:
                         namespace._argument_experimentals.append(experimental_info)  # pylint: disable=protected-access
                     try:
-                        super(ExperimentalArgumentAction, self).__call__(parser, namespace, values, option_string)
+                        super().__call__(parser, namespace, values, option_string)
                     except NotImplementedError:
                         setattr(namespace, self.dest, values)
 

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -279,8 +279,8 @@ class CLICommandsLoader(object):
             if isinstance(op, types.FunctionType):
                 return op
             return six.get_method_function(op)
-        except (ValueError, AttributeError):
-            raise ValueError("The operation '{}' is invalid.".format(operation))
+        except (ValueError, AttributeError) as ex:
+            raise ValueError("The operation '{}' is invalid.".format(operation)) from ex
 
     def deprecate(self, **kwargs):
         kwargs['object_type'] = 'command group'

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -276,6 +276,7 @@ class CLICommandsLoader(object):
                 op = getattr(op, part)
             if isinstance(op, types.FunctionType):
                 return op
+            # op as types.MethodType
             return op.__func__
         except (ValueError, AttributeError) as ex:
             raise ValueError("The operation '{}' is invalid.".format(operation)) from ex

--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -86,7 +86,7 @@ class Deprecated(StatusTag):
         self.expiration = expiration
         self._cli_version = cli_ctx.get_cli_version()
 
-        super(Deprecated, self).__init__(
+        super().__init__(
             cli_ctx=cli_ctx,
             object_type=object_type,
             target=target,
@@ -138,4 +138,4 @@ class ImplicitDeprecated(Deprecated):
             'tag_func': lambda _: '',
             'message_func': get_implicit_deprecation_message
         })
-        super(ImplicitDeprecated, self).__init__(**kwargs)
+        super().__init__(**kwargs)

--- a/knack/experimental.py
+++ b/knack/experimental.py
@@ -52,7 +52,7 @@ class ExperimentalItem(StatusTag):
         def _default_get_message(self):
             return status_tag_messages['experimental'].format("This " + self.object_type)
 
-        super(ExperimentalItem, self).__init__(
+        super().__init__(
             cli_ctx=cli_ctx,
             object_type=object_type,
             target=target,
@@ -73,4 +73,4 @@ class ImplicitExperimentalItem(ExperimentalItem):
             'tag_func': lambda _: '',
             'message_func': get_implicit_experimental_message
         })
-        super(ImplicitExperimentalItem, self).__init__(**kwargs)
+        super().__init__(**kwargs)

--- a/knack/help.py
+++ b/knack/help.py
@@ -92,7 +92,7 @@ class HelpObject(object):
     def __init__(self, **kwargs):
         self._short_summary = ''
         self._long_summary = ''
-        super(HelpObject, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     @property
     def short_summary(self):
@@ -123,7 +123,7 @@ class HelpFile(HelpObject):
             return text
 
     def __init__(self, help_ctx, delimiters):  # pylint: disable=too-many-statements
-        super(HelpFile, self).__init__()
+        super().__init__()
         self.help_ctx = help_ctx
         self.delimiters = delimiters
         self.name = delimiters.split()[-1] if delimiters else delimiters
@@ -242,7 +242,7 @@ class GroupHelpFile(HelpFile):
 
     def __init__(self, help_ctx, delimiters, parser):
 
-        super(GroupHelpFile, self).__init__(help_ctx, delimiters)
+        super().__init__(help_ctx, delimiters)
         self.type = 'group'
 
         self.children = []
@@ -266,7 +266,7 @@ class CommandHelpFile(HelpFile):
 
     def __init__(self, help_ctx, delimiters, parser):
 
-        super(CommandHelpFile, self).__init__(help_ctx, delimiters)
+        super().__init__(help_ctx, delimiters)
         self.type = 'command'
 
         self.parameters = []
@@ -325,7 +325,7 @@ class CommandHelpFile(HelpFile):
         self.parameters.append(HelpParameter(**param_kwargs))
 
     def _load_from_data(self, data):
-        super(CommandHelpFile, self)._load_from_data(data)
+        super()._load_from_data(data)
 
         if isinstance(data, str) or not self.parameters or not data.get('parameters'):
             return
@@ -345,7 +345,7 @@ class HelpParameter(HelpObject):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, name_source, description, required, choices=None, default=None, group_name=None,
                  deprecate_info=None, preview_info=None, experimental_info=None, default_value_source=None):
-        super(HelpParameter, self).__init__()
+        super().__init__()
         self.name_source = name_source
         self.name = ' '.join(sorted(name_source))
         self.required = required

--- a/knack/output.py
+++ b/knack/output.py
@@ -76,11 +76,11 @@ def format_table(obj):
         should_sort_keys = not obj.is_query_active and not obj.table_transformer
         to = _TableOutput(should_sort_keys)
         return to.dump(result_list)
-    except:
+    except Exception as ex:
         logger.debug(traceback.format_exc())
         raise CLIError("Table output unavailable. "
                        "Use the --query option to specify an appropriate query. "
-                       "Use --debug for more info.")
+                       "Use --debug for more info.") from ex
 
 
 def format_tsv(obj):

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -109,7 +109,7 @@ class CLICommandParser(argparse.ArgumentParser):
         # or description for a command. We better stash it away before handing it off for
         # "normal" argparse handling...
         self._description = kwargs.pop('description', None)
-        super(CLICommandParser, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def load_command_table(self, command_loader):
         """ Process the command table and load it into the parser
@@ -223,7 +223,7 @@ class CLICommandParser(argparse.ArgumentParser):
         return parent_subparser
 
     def validation_error(self, message):
-        return super(CLICommandParser, self).error(message)
+        return super().error(message)
 
     def is_group(self):
         """ Determine if this parser instance represents a group
@@ -259,7 +259,7 @@ class CLICommandParser(argparse.ArgumentParser):
         by ArgumentParser.parse_args as usual
         """
         self._expand_prefixed_files(args)
-        return super(CLICommandParser, self).parse_args(args)
+        return super().parse_args(args)
 
     def _check_value(self, action, value):
         # Override to customize the error message when a argument is not among the available choices

--- a/knack/preview.py
+++ b/knack/preview.py
@@ -52,7 +52,7 @@ class PreviewItem(StatusTag):
         def _default_get_message(self):
             return status_tag_messages['preview'].format("This " + self.object_type)
 
-        super(PreviewItem, self).__init__(
+        super().__init__(
             cli_ctx=cli_ctx,
             object_type=object_type,
             target=target,
@@ -73,4 +73,4 @@ class ImplicitPreviewItem(PreviewItem):
             'tag_func': lambda _: '',
             'message_func': get_implicit_preview_message
         })
-        super(ImplicitPreviewItem, self).__init__(**kwargs)
+        super().__init__(**kwargs)

--- a/knack/query.py
+++ b/knack/query.py
@@ -22,9 +22,9 @@ class CLIQuery(object):
         from jmespath import compile as compile_jmespath
         try:
             return compile_jmespath(raw_query)
-        except KeyError:
+        except KeyError as ex:
             # Raise a ValueError which argparse can handle
-            raise ValueError
+            raise ValueError from ex
 
     @staticmethod
     def on_global_arguments(_, **kwargs):

--- a/knack/testsdk/base.py
+++ b/knack/testsdk/base.py
@@ -26,7 +26,7 @@ logger = logging.getLogger('clicore.testsdk')
 
 class IntegrationTestBase(unittest.TestCase):
     def __init__(self, cli, method_name):
-        super(IntegrationTestBase, self).__init__(method_name)
+        super().__init__(method_name)
         self.cli = cli
         self.diagnose = os.environ.get(ENV_TEST_DIAGNOSE, None) == 'True'
 
@@ -82,7 +82,7 @@ class LiveTest(IntegrationTestBase):
 class ScenarioTest(IntegrationTestBase):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, cli, method_name, filter_headers=None):
-        super(ScenarioTest, self).__init__(cli, method_name)
+        super().__init__(cli, method_name)
         self.name_replacer = GeneralNameReplacer()
         self.recording_processors = [LargeRequestBodyProcessor(),
                                      LargeResponseBodyProcessor(),
@@ -113,7 +113,7 @@ class ScenarioTest(IntegrationTestBase):  # pylint: disable=too-many-instance-at
         self.original_env = os.environ.copy()
 
     def setUp(self):
-        super(ScenarioTest, self).setUp()
+        super().setUp()
 
         # set up cassette
         cm = self.vcr.use_cassette(self.recording_file)

--- a/knack/testsdk/base.py
+++ b/knack/testsdk/base.py
@@ -251,7 +251,7 @@ class ExecutionResult(object):
             self.exit_code = self.cli.invoke(shlex.split(command), out_file=out_buffer) or 0
             self.output = out_buffer.getvalue()
         except vcr.errors.CannotOverwriteExistingCassetteException as ex:
-            raise AssertionError(ex)
+            raise AssertionError(ex) from ex
         except CliExecutionError as ex:
             if ex.exception:
                 raise ex.exception

--- a/knack/testsdk/checkers.py
+++ b/knack/testsdk/checkers.py
@@ -63,9 +63,9 @@ class NoneCheck(object):  # pylint: disable=too-few-public-methods
         try:
             data = execution_result.output.strip()
             assert not data or data in none_strings
-        except AssertionError:
+        except AssertionError as ex:
             raise AssertionError("Actual value '{}' != Expected value falsy (None, '', []) or "
-                                 "string in {}".format(data, none_strings))
+                                 "string in {}".format(data, none_strings)) from ex
 
 
 class StringCheck(object):  # pylint: disable=too-few-public-methods
@@ -76,9 +76,9 @@ class StringCheck(object):  # pylint: disable=too-few-public-methods
         try:
             result = execution_result.output.strip().strip('"')
             assert result == self.expected_result
-        except AssertionError:
+        except AssertionError as ex:
             raise AssertionError(
-                "Actual value '{}' != Expected value {}".format(result, self.expected_result))
+                "Actual value '{}' != Expected value {}".format(result, self.expected_result)) from ex
 
 
 class StringContainCheck(object):  # pylint: disable=too-few-public-methods
@@ -89,7 +89,7 @@ class StringContainCheck(object):  # pylint: disable=too-few-public-methods
         try:
             result = execution_result.output.strip('"')
             assert self.expected_result in result
-        except AssertionError:
+        except AssertionError as ex:
             raise AssertionError(
                 "Actual value '{}' doesn't contain Expected value {}".format(result,
-                                                                             self.expected_result))
+                                                                             self.expected_result)) from ex

--- a/knack/testsdk/exceptions.py
+++ b/knack/testsdk/exceptions.py
@@ -7,19 +7,18 @@
 class CliTestError(Exception):
     def __init__(self, error_message):
         message = 'An error caused by the CLI test harness failed the test: {}'
-        super(CliTestError, self).__init__(message.format(error_message))
+        super().__init__(message.format(error_message))
 
 
 class CliExecutionError(Exception):
     def __init__(self, exception):
         self.exception = exception
         message = 'The CLI throws exception {} during execution and fails the command.'
-        super(CliExecutionError, self).__init__(message.format(exception.__class__.__name__,
-                                                               exception))
+        super().__init__(message.format(exception.__class__.__name__, exception))
 
 
 class JMESPathCheckAssertionError(AssertionError):
     def __init__(self, query, expected, actual, json_data):
         message = "Query '{}' doesn't yield expected value '{}', instead the actual value " \
                   "is '{}'. Data: \n{}\n".format(query, expected, actual, json_data)
-        super(JMESPathCheckAssertionError, self).__init__(message)
+        super().__init__(message)

--- a/knack/util.py
+++ b/knack/util.py
@@ -42,8 +42,7 @@ class CtxTypeError(TypeError):
 
     def __init__(self, obj):
         from .cli import CLI
-        super(CtxTypeError, self).__init__('expected instance of {} got {}'.format(CLI.__name__,
-                                                                                   obj.__class__.__name__))
+        super().__init__('expected instance of {} got {}'.format(CLI.__name__, obj.__class__.__name__))
 
 
 class ColorizedString(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 argcomplete==1.11.1
 colorama==0.4.3
-flake8==3.7.9
+flake8==3.8.4
 jmespath==0.9.5
 mock==4.0.1
-pylint==2.5.3
+pylint==2.6.0
 Pygments==2.5.2
 PyYAML==5.3.1
 six==1.14.0

--- a/tests/test_cli_scenarios.py
+++ b/tests/test_cli_scenarios.py
@@ -158,7 +158,7 @@ class TestCLIScenarios(unittest.TestCase):
     def test_init_log(self):
         class MyCLI(CLI):
             def __init__(self, **kwargs):
-                super(MyCLI, self).__init__(**kwargs)
+                super().__init__(**kwargs)
                 self.init_debug_log.append("init debug log: 6aa19a11")
                 self.init_info_log.append("init info log: b0746f58")
         cli = MyCLI()

--- a/tests/test_command_with_configured_defaults.py
+++ b/tests/test_command_with_configured_defaults.py
@@ -42,7 +42,7 @@ class TestCommandWithConfiguredDefaults(unittest.TestCase):
         class TestCommandsLoader(CLICommandsLoader):
 
             def load_command_table(self, args):
-                super(TestCommandsLoader, self).load_command_table(args)
+                super().load_command_table(args)
                 with CommandGroup(self, 'foo', '{}#{{}}'.format(__name__)) as g:
                     g.command('list', 'list_foo')
                 return self.command_table
@@ -51,7 +51,7 @@ class TestCommandWithConfiguredDefaults(unittest.TestCase):
                 with ArgumentsContext(self, 'foo') as c:
                     c.argument('my_param', options_list='--my-param',
                                configured_default='param', required=required)
-                super(TestCommandsLoader, self).load_arguments(command)
+                super().load_arguments(command)
         self.cli_ctx = DummyCLI(commands_loader_cls=TestCommandsLoader)
 
     @mock.patch.dict(os.environ, {'CLI_DEFAULTS_PARAM': 'myVal'})

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -37,7 +37,7 @@ class TestCommandDeprecation(unittest.TestCase):
 
         class DeprecationTestCommandLoader(CLICommandsLoader):
             def load_command_table(self, args):
-                super(DeprecationTestCommandLoader, self).load_command_table(args)
+                super().load_command_table(args)
                 with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
                     g.command('cmd1', 'example_handler', deprecate_info=g.deprecate(redirect='alt-cmd1'))
                     g.command('cmd2', 'example_handler', deprecate_info=g.deprecate(redirect='alt-cmd2', hide='1.0.0'))
@@ -55,7 +55,7 @@ class TestCommandDeprecation(unittest.TestCase):
                     c.argument('arg1', options_list=['--arg', '-a'], required=False, type=int, choices=[1, 2, 3])
                     c.argument('arg2', options_list=['-b'], required=True, choices=['a', 'b', 'c'])
 
-                super(DeprecationTestCommandLoader, self).load_arguments(command)
+                super().load_arguments(command)
 
         helps['grp1'] = """
     type: group
@@ -165,7 +165,7 @@ class TestCommandGroupDeprecation(unittest.TestCase):
 
         class DeprecationTestCommandLoader(CLICommandsLoader):
             def load_command_table(self, args):
-                super(DeprecationTestCommandLoader, self).load_command_table(args)
+                super().load_command_table(args)
 
                 with CommandGroup(self, 'group1', '{}#{{}}'.format(__name__), deprecate_info=self.deprecate(redirect='alt-group1')) as g:
                     g.command('cmd1', 'example_handler')
@@ -189,7 +189,7 @@ class TestCommandGroupDeprecation(unittest.TestCase):
                     c.argument('arg1', options_list=['--arg', '-a'], required=False, type=int, choices=[1, 2, 3])
                     c.argument('arg2', options_list=['-b'], required=True, choices=['a', 'b', 'c'])
 
-                super(DeprecationTestCommandLoader, self).load_arguments(command)
+                super().load_arguments(command)
 
         helps['group1'] = """
     type: group
@@ -295,7 +295,7 @@ class TestArgumentDeprecation(unittest.TestCase):
 
         class DeprecationTestCommandLoader(CLICommandsLoader):
             def load_command_table(self, args):
-                super(DeprecationTestCommandLoader, self).load_command_table(args)
+                super().load_command_table(args)
                 with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
                     g.command('arg-test', 'example_arg_handler')
                 return self.command_table
@@ -313,7 +313,7 @@ class TestArgumentDeprecation(unittest.TestCase):
                     c.argument('arg5', deprecate_info=c.deprecate(expiration='0.1.0'))
                     c.argument('opt5', options_list=['--opt5', c.deprecate(redirect='--opt5', target='--alt5', expiration='0.1.0')])
 
-                super(DeprecationTestCommandLoader, self).load_arguments(command)
+                super().load_arguments(command)
 
         helps['grp1'] = """
     type: group

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -62,7 +62,7 @@ class TestHelp(unittest.TestCase):
 
         class HelpTestCommandLoader(CLICommandsLoader):
             def load_command_table(self, args):
-                super(HelpTestCommandLoader, self).load_command_table(args)
+                super().load_command_table(args)
                 with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
                     g.command('n1', 'example_handler')
                     g.command('n2', 'example_handler')
@@ -90,7 +90,7 @@ class TestHelp(unittest.TestCase):
                         c.argument('arg2', options_list=['--foobar2'], required=True)
                         c.argument('arg3', options_list=['--foobar3'], help='the foobar3')
 
-                super(HelpTestCommandLoader, self).load_arguments(command)
+                super().load_arguments(command)
 
         helps['n2'] = """
     type: command

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -39,7 +39,7 @@ class TestCommandPreview(unittest.TestCase):
 
         class PreviewTestCommandLoader(CLICommandsLoader):
             def load_command_table(self, args):
-                super(PreviewTestCommandLoader, self).load_command_table(args)
+                super().load_command_table(args)
                 with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
                     g.command('cmd1', 'example_handler', is_preview=True)
 
@@ -53,7 +53,7 @@ class TestCommandPreview(unittest.TestCase):
                     c.argument('arg1', options_list=['--arg', '-a'], required=False, type=int, choices=[1, 2, 3])
                     c.argument('arg2', options_list=['-b'], required=True, choices=['a', 'b', 'c'])
 
-                super(PreviewTestCommandLoader, self).load_arguments(command)
+                super().load_arguments(command)
 
         helps['grp1'] = """
     type: group
@@ -139,7 +139,7 @@ class TestCommandGroupPreview(unittest.TestCase):
 
         class PreviewTestCommandLoader(CLICommandsLoader):
             def load_command_table(self, args):
-                super(PreviewTestCommandLoader, self).load_command_table(args)
+                super().load_command_table(args)
 
                 with CommandGroup(self, 'group1', '{}#{{}}'.format(__name__), is_preview=True) as g:
                     g.command('cmd1', 'example_handler')
@@ -151,7 +151,7 @@ class TestCommandGroupPreview(unittest.TestCase):
                     c.argument('arg1', options_list=['--arg', '-a'], required=False, type=int, choices=[1, 2, 3])
                     c.argument('arg2', options_list=['-b'], required=True, choices=['a', 'b', 'c'])
 
-                super(PreviewTestCommandLoader, self).load_arguments(command)
+                super().load_arguments(command)
 
         helps['group1'] = """
     type: group
@@ -220,7 +220,7 @@ class TestArgumentPreview(unittest.TestCase):
 
         class PreviewTestCommandLoader(CLICommandsLoader):
             def load_command_table(self, args):
-                super(PreviewTestCommandLoader, self).load_command_table(args)
+                super().load_command_table(args)
                 with CommandGroup(self, '', '{}#{{}}'.format(__name__)) as g:
                     g.command('arg-test', 'example_arg_handler')
                 return self.command_table
@@ -229,7 +229,7 @@ class TestArgumentPreview(unittest.TestCase):
                 with ArgumentsContext(self, 'arg-test') as c:
                     c.argument('arg1', help='Arg1', is_preview=True, action=LoggerAction)
 
-                super(PreviewTestCommandLoader, self).load_arguments(command)
+                super().load_arguments(command)
 
         helps['grp1'] = """
     type: group

--- a/tests/util.py
+++ b/tests/util.py
@@ -61,7 +61,7 @@ def remove_space(str):
 class MockContext(CLI):
 
     def __init__(self):
-        super(MockContext, self).__init__(config_dir=new_temp_folder())
+        super().__init__(config_dir=new_temp_folder())
         loader = CLICommandsLoader(cli_ctx=self)
         invocation = mock.MagicMock(spec=CommandInvoker)
         invocation.data = {}
@@ -76,7 +76,7 @@ class DummyCLI(CLI):
 
     def __init__(self, **kwargs):
         kwargs['config_dir'] = new_temp_folder()
-        super(DummyCLI, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # Force colorama to initialize
         self.enable_color = True
 


### PR DESCRIPTION
Bump pylint and flake8 to the latest version to make sure the code comply with the latest Python 3 standards. 