### PR TITLE
Drop Python 2 compatible code

### DIFF
--- a/knack/cli.py
+++ b/knack/cli.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import os
 import sys
 from collections import defaultdict

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -7,8 +7,6 @@ import types
 from collections import OrderedDict, defaultdict
 from importlib import import_module
 
-import six
-
 from .deprecation import Deprecated
 from .preview import PreviewItem
 from .experimental import ExperimentalItem
@@ -152,7 +150,7 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         if callable(confirmation):
             return confirmation(command_args)
         try:
-            if isinstance(confirmation, six.string_types):
+            if isinstance(confirmation, str):
                 return prompt_y_n(confirmation)
             return prompt_y_n('Are you sure you want to perform this operation?')
         except NoTTYException:
@@ -242,7 +240,7 @@ class CLICommandsLoader(object):
 
     def create_command(self, name, operation, **kwargs):
         """ Constructs the command object that can then be added to the command table """
-        if not isinstance(operation, six.string_types):
+        if not isinstance(operation, str):
             raise ValueError("Operation must be a string. Got '{}'".format(operation))
 
         name = ' '.join(name.split())
@@ -278,7 +276,8 @@ class CLICommandsLoader(object):
                 op = getattr(op, part)
             if isinstance(op, types.FunctionType):
                 return op
-            return six.get_method_function(op)
+            # MethodType
+            return op.__func__
         except (ValueError, AttributeError):
             raise ValueError("The operation '{}' is invalid.".format(operation))
 

--- a/knack/deprecation.py
+++ b/knack/deprecation.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from six import string_types as STRING_TYPES
-
 from .util import StatusTag
 
 DEFAULT_DEPRECATED_TAG = '[Deprecated]'
@@ -40,7 +38,7 @@ class Deprecated(StatusTag):
         deprecate_info = kwargs.get('deprecate_info', None)
         if isinstance(deprecate_info, Deprecated):
             deprecate_info.object_type = object_type
-        elif isinstance(deprecate_info, STRING_TYPES):
+        elif isinstance(deprecate_info, str):
             deprecate_info = Deprecated(cli_ctx, redirect=deprecate_info, object_type=object_type)
         kwargs['deprecate_info'] = deprecate_info
         return deprecate_info
@@ -111,7 +109,7 @@ class Deprecated(StatusTag):
         hidden = False
         if isinstance(self.hide, bool):
             hidden = self.hide
-        elif isinstance(self.hide, STRING_TYPES):
+        elif isinstance(self.hide, str):
             hidden = self._version_less_than_or_equal_to(self.hide, self._cli_version)
         return hidden
 

--- a/knack/help.py
+++ b/knack/help.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function, unicode_literals
 import argparse
 import sys
 import textwrap

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import sys
 
 from collections import defaultdict

--- a/knack/output.py
+++ b/knack/output.py
@@ -3,24 +3,22 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import errno
 import json
 import traceback
 from collections import OrderedDict
-from six import StringIO, text_type, u, string_types
+from io import StringIO
 
-from .util import CLIError, CommandResultItem, CtxTypeError
 from .events import EVENT_INVOKER_POST_PARSE_ARGS, EVENT_PARSER_GLOBAL_CREATE
 from .log import get_logger
+from .util import CLIError, CommandResultItem, CtxTypeError
 
 logger = get_logger(__name__)
 
 
 def _decode_str(output):
-    if not isinstance(output, text_type):
-        output = u(str(output))
+    if not isinstance(output, str):
+        output = str(output)
     return output
 
 
@@ -227,7 +225,7 @@ class _TsvOutput(object):  # pylint: disable=too-few-public-methods
             # and a dictionary value in other...
             stream.write('')
         else:
-            to_write = data if isinstance(data, string_types) else str(data)
+            to_write = data if isinstance(data, str) else str(data)
             stream.write(to_write)
 
     @staticmethod

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import argparse
 
 from .deprecation import Deprecated

--- a/knack/prompting.py
+++ b/knack/prompting.py
@@ -3,10 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import sys
 import getpass
-from six.moves import input
 
 from .log import get_logger
 

--- a/knack/testsdk/base.py
+++ b/knack/testsdk/base.py
@@ -11,7 +11,7 @@ import shlex
 import tempfile
 import shutil
 import logging
-import six
+import io
 import vcr
 
 from .patches import patch_time_sleep_api
@@ -161,7 +161,7 @@ class ScenarioTest(IntegrationTestBase):  # pylint: disable=too-many-instance-at
             response['headers'] = headers
 
             body = response['body']['string']
-            if body and not isinstance(body, six.string_types):
+            if body and not isinstance(body, str):
                 response['body']['string'] = body.decode('utf-8')
 
             for processor in self.recording_processors:
@@ -179,7 +179,7 @@ class ScenarioTest(IntegrationTestBase):  # pylint: disable=too-many-instance-at
     @classmethod
     def _custom_request_query_matcher(cls, r1, r2):
         """ Ensure method, path, and query parameters match. """
-        from six.moves.urllib_parse import urlparse, parse_qs  # pylint: disable=useless-suppression
+        from urllib.parse import urlparse, parse_qs  # pylint: disable=useless-suppression
 
         url1 = urlparse(r1.uri)
         url2 = urlparse(r2.uri)
@@ -244,7 +244,7 @@ class ExecutionResult(object):
         if command.startswith(cli_name_prefixed):
             command = command[len(cli_name_prefixed):]
 
-        out_buffer = six.StringIO()
+        out_buffer = io.StringIO()
         try:
             # issue: stderr cannot be redirect in this form, as a result some failure information
             # is lost when command fails.

--- a/knack/testsdk/recording_processors.py
+++ b/knack/testsdk/recording_processors.py
@@ -57,12 +57,11 @@ class LargeResponseBodyProcessor(RecordingProcessor):
 
 class LargeResponseBodyReplacer(RecordingProcessor):
     def process_response(self, response):
-        import six
         body = response['body']['string']
 
         # backward compatibility. under 2.7 response body is unicode, under 3.5 response body is
         # bytes. when set the value back, the same type must be used.
-        body_is_string = isinstance(body, six.string_types)
+        body_is_string = isinstance(body, str)
 
         content_in_string = (response['body']['string'] or b'').decode('utf-8')
         index = content_in_string.find(LargeResponseBodyProcessor.control_flag)

--- a/scripts/license_verify.py
+++ b/scripts/license_verify.py
@@ -5,7 +5,6 @@
 
 # Verify that all *.py files have a license header in the file.
 
-from __future__ import print_function
 import os
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
@@ -17,7 +16,6 @@ DEPENDENCIES = [
     'jmespath',
     'pygments',
     'pyyaml',
-    'six',
     'tabulate'
 ]
 

--- a/tests/test_cli_scenarios.py
+++ b/tests/test_cli_scenarios.py
@@ -12,7 +12,7 @@ except ImportError:
     from unittest import mock
 import mock
 
-from six import StringIO
+from io import StringIO
 
 from knack import CLI
 from knack.commands import CLICommand, CLICommandsLoader

--- a/tests/test_command_with_configured_defaults.py
+++ b/tests/test_command_with_configured_defaults.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from __future__ import print_function
 import os
 import logging
 import sys

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import unicode_literals
-
 import unittest
 try:
     import mock

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import unicode_literals, print_function
-
 import unittest
 try:
     import mock

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -6,12 +6,10 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import unittest
 import mock
 from collections import OrderedDict
-from six import StringIO
+from io import StringIO
 
 from knack.output import OutputProducer, format_json, format_json_color, format_yaml, format_yaml_color, \
     format_table, format_tsv

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-from six import StringIO
+from io import StringIO
 
 from knack.parser import CLICommandParser
 from knack.commands import CLICommand

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -3,9 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import unicode_literals, print_function
-
-import os
 import unittest
 try:
     import mock

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -9,7 +9,7 @@ try:
     import mock
 except ImportError:
     from unittest import mock
-from six import StringIO
+from io import StringIO
 
 from knack.prompting import (verify_is_a_tty, NoTTYException, _INVALID_PASSWORD_MSG, prompt,
                              prompt_int, prompt_pass, prompt_y_n, prompt_t_f, prompt_choice_list)

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import shutil
 import os
-from six import StringIO
+from io import StringIO
 import logging
 from knack.log import CLI_LOGGER_NAME
 


### PR DESCRIPTION
Drop Python 2 compatible code by:

- removing `six` (same as https://github.com/Azure/azure-cli/pull/16082)
- removing `from __future__ import print_function`