### PR TITLE
Add raw_result to CommandResultItem

### DIFF
--- a/knack/cli.py
+++ b/knack/cli.py
@@ -236,7 +236,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
                 if cmd_result and cmd_result.result is not None:
                     formatter = self.output.get_formatter(output_type)
                     self.output.out(cmd_result, formatter=formatter, out_file=out_file)
-                self.raise_event(EVENT_CLI_SUCCESSFUL_EXECUTE, result=cmd_result.result)
+                self.raise_event(EVENT_CLI_SUCCESSFUL_EXECUTE, result=cmd_result)
         except KeyboardInterrupt as ex:
             exit_code = 1
             self.result = CommandResultItem(None, error=ex, exit_code=exit_code)

--- a/knack/invocation.py
+++ b/knack/invocation.py
@@ -230,4 +230,5 @@ class CommandInvoker(object):
         return CommandResultItem(event_data['result'],
                                  exit_code=0,
                                  table_transformer=cmd_tbl[parsed_args.command].table_transformer,
-                                 is_query_active=self.data['query_active'])
+                                 is_query_active=self.data['query_active'],
+                                 raw_result=cmd_result)

--- a/knack/util.py
+++ b/knack/util.py
@@ -22,12 +22,14 @@ status_tag_messages = {
 
 class CommandResultItem(object):  # pylint: disable=too-few-public-methods
     def __init__(self, result, table_transformer=None, is_query_active=False,
-                 exit_code=0, error=None):
+                 exit_code=0, error=None, raw_result=None):
         self.result = result
         self.error = error
         self.exit_code = exit_code
         self.table_transformer = table_transformer
         self.is_query_active = is_query_active
+        # The result before applying query
+        self.raw_result = raw_result
 
 
 class CLIError(Exception):


### PR DESCRIPTION
Add `raw_result` to `CommandResultItem`, so that the raw result (before query) can be used by post-output hint (https://github.com/Azure/azure-cli/pull/16242).