### PR TITLE
Fix incorrect error message for arguments with choices

### DIFF
--- a/knack/parser.py
+++ b/knack/parser.py
@@ -265,6 +265,8 @@ class CLICommandParser(argparse.ArgumentParser):
         import difflib
         import sys
 
+        super(CLICommandParser, self)._check_value(action, value)
+
         if action.choices is not None and value not in action.choices:
             # parser has no `command_source`, value is part of command itself
             error_msg = "{prog}: '{value}' is not in the '{prog}' command group. See '{prog} --help'.".format(

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -35,7 +35,7 @@ def _get_action_name(argument):
     if argument is None:
         return None
     if argument.option_strings:
-        return  '/'.join(argument.option_strings)
+        return '/'.join(argument.option_strings)
     if argument.metavar not in (None, argparse.SUPPRESS):
         return argument.metavar
     if argument.dest not in (None, argparse.SUPPRESS):


### PR DESCRIPTION
- If user provided an invalid value for an argument with a list of choices, then the error message will not indicate this. Rather it will indicate that cli command group is invalid. This is a quick fix and I am not sure that it doesn't break Knack. From my tests, this fix is better than removing overridden _check_value method.

Fixes #236 