### PR TITLE
Init colorama only in Windows legacy terminal

### DIFF
--- a/knack/cli.py
+++ b/knack/cli.py
@@ -21,10 +21,6 @@ from .help import CLIHelp
 
 logger = get_logger(__name__)
 
-# Temporarily force color to be enabled even when out_file is not stdout.
-# This is only intended for testing purpose.
-_KNACK_TEST_FORCE_ENABLE_COLOR = False
-
 
 class CLI(object):  # pylint: disable=too-many-instance-attributes
     """ The main driver for the CLI """
@@ -209,7 +205,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
         exit_code = 0
         try:
             out_file = out_file or self.out_file
-            if out_file is sys.stdout and self._should_init_colorama or _KNACK_TEST_FORCE_ENABLE_COLOR:
+            if out_file is sys.stdout and self._should_init_colorama:
                 self.init_debug_log.append("Init colorama.")
                 import colorama
                 colorama.init()
@@ -253,7 +249,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
         finally:
             self.raise_event(EVENT_CLI_POST_EXECUTE)
 
-            if self._should_init_colorama or _KNACK_TEST_FORCE_ENABLE_COLOR:
+            if self._should_init_colorama:
                 import colorama
                 colorama.deinit()
 

--- a/knack/cli.py
+++ b/knack/cli.py
@@ -101,6 +101,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
 
         self.only_show_errors = self.config.getboolean('core', 'only_show_errors', fallback=False)
         self.enable_color = self._should_enable_color()
+        self._should_init_colorama = self.enable_color and os.name == 'nt'
 
     @staticmethod
     def _should_show_version(args):
@@ -207,7 +208,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
         exit_code = 0
         try:
             out_file = out_file or self.out_file
-            if out_file is sys.stdout and self.enable_color or _KNACK_TEST_FORCE_ENABLE_COLOR:
+            if out_file is sys.stdout and self._should_init_colorama or _KNACK_TEST_FORCE_ENABLE_COLOR:
                 import colorama
                 colorama.init()
                 # point out_file to the new sys.stdout which is overwritten by colorama
@@ -250,7 +251,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
         finally:
             self.raise_event(EVENT_CLI_POST_EXECUTE)
 
-            if self.enable_color or _KNACK_TEST_FORCE_ENABLE_COLOR:
+            if self._should_init_colorama or _KNACK_TEST_FORCE_ENABLE_COLOR:
                 import colorama
                 colorama.deinit()
 

--- a/knack/util.py
+++ b/knack/util.py
@@ -142,3 +142,24 @@ def todict(obj, post_processor=None):  # pylint: disable=too-many-return-stateme
                   if not callable(v) and not k.startswith('_')}
         return post_processor(obj, result) if post_processor else result
     return obj
+
+
+def is_modern_terminal():
+    """Detect whether the current terminal is a modern terminal that supports Unicode and
+    Console Virtual Terminal Sequences.
+
+    Currently, these terminals can be detected:
+      - VS Code terminal
+      - PyCharm
+      - Windows Terminal
+    """
+    # VS Code: https://github.com/microsoft/vscode/pull/30346
+    if os.environ.get('TERM_PROGRAM', '').lower() == 'vscode':
+        return True
+    # PyCharm: https://youtrack.jetbrains.com/issue/PY-4853
+    if 'PYCHARM_HOSTED' in os.environ:
+        return True
+    # Windows Terminal: https://github.com/microsoft/terminal/issues/1040
+    if 'WT_SESSION' in os.environ:
+        return True
+    return False

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -8,12 +8,11 @@ try:
     import mock
 except ImportError:
     from unittest import mock
-from threading import Lock
 
 from knack.arguments import ArgumentsContext
-from knack.commands import CLICommand, CLICommandsLoader, CommandGroup
+from knack.commands import CLICommandsLoader, CommandGroup
 
-from tests.util import DummyCLI, redirect_io, disable_color
+from tests.util import DummyCLI, redirect_io, assert_in_multi_line, disable_color
 
 
 def example_handler(arg1, arg2=None, arg3=None):
@@ -80,7 +79,7 @@ Commands:
     cmd4 [Deprecated] : Short summary here.
 
 """.format(self.cli_ctx.name)
-        self.assertEqual(expected, actual)
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     def test_deprecate_command_help_hidden(self):
@@ -100,7 +99,7 @@ Arguments
     --arg -a           : Allowed values: 1, 2, 3.
     --arg3
 """.format(self.cli_ctx.name)
-        self.assertIn(expected, actual)
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     def test_deprecate_command_plain_execute(self):
@@ -211,7 +210,7 @@ Commands:
     cmd1 : Short summary here.
 
 """.format(self.cli_ctx.name)
-        self.assertEqual(expected, actual)
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     def test_deprecate_command_group_help_hidden(self):
@@ -229,7 +228,7 @@ Commands:
     cmd1 : Short summary here.
 
 """.format(self.cli_ctx.name)
-        self.assertIn(expected, actual)
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     def test_deprecate_command_group_help_expiring(self):
@@ -243,7 +242,7 @@ Group
         This command group has been deprecated and will be removed in version '1.0.0'. Use
         'alt-group4' instead.
 """.format(self.cli_ctx.name)
-        self.assertIn(expected, actual)
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     @disable_color
@@ -282,7 +281,7 @@ Command
         This command is implicitly deprecated because command group 'group1' is deprecated and
         will be removed in a future release. Use 'alt-group1' instead.
 """.format(self.cli_ctx.name)
-        self.assertIn(expected, actual)
+        assert_in_multi_line(expected, actual)
 
 
 class TestArgumentDeprecation(unittest.TestCase):
@@ -352,7 +351,7 @@ Arguments
     --opt4
     --opt5
 """.format(self.cli_ctx.name)
-        self.assertTrue(actual.startswith(expected))
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     def test_deprecate_arguments_execute(self):

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -15,7 +15,7 @@ import argparse
 from knack.arguments import ArgumentsContext
 from knack.commands import CLICommandsLoader, CommandGroup
 
-from tests.util import DummyCLI, redirect_io, remove_space
+from tests.util import DummyCLI, redirect_io, assert_in_multi_line
 
 
 def example_handler(arg1, arg2=None, arg3=None):
@@ -64,7 +64,7 @@ class TestCommandExperimental(unittest.TestCase):
         self.cli_ctx.invoke('grp1 cmd1 -b b'.split())
         actual = self.io.getvalue()
         expected = "Command group 'grp1' is experimental and under development."
-        self.assertIn(remove_space(expected), remove_space(actual))
+        self.assertIn(expected, actual)
 
     @redirect_io
     def test_experimental_command_group_help(self):
@@ -83,7 +83,7 @@ Commands:
     cmd1 [Experimental] : Short summary here.
 
 """.format(self.cli_ctx.name)
-        self.assertEqual(expected, actual)
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     def test_experimental_command_plain_execute(self):
@@ -91,7 +91,7 @@ Commands:
         self.cli_ctx.invoke('cmd1 -b b'.split())
         actual = self.io.getvalue()
         expected = "This command is experimental and under development."
-        self.assertIn(remove_space(expected), remove_space(actual))
+        self.assertIn(expected, actual)
 
 
 class TestCommandGroupExperimental(unittest.TestCase):
@@ -136,7 +136,7 @@ Commands:
     cmd1 : Short summary here.
 
 """.format(self.cli_ctx.name)
-        self.assertIn(remove_space(expected), remove_space(actual))
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     def test_experimental_command_implicitly(self):
@@ -150,7 +150,7 @@ Command
         Long summary here. Still long summary.
         Command group 'group1' is experimental and under development.
 """.format(self.cli_ctx.name)
-        self.assertIn(remove_space(expected), remove_space(actual))
+        assert_in_multi_line(expected, actual)
 
 
 class TestArgumentExperimental(unittest.TestCase):
@@ -193,7 +193,7 @@ Arguments
     --arg1 [Experimental] [Required] : Arg1.
         Argument '--arg1' is experimental and under development.
 """.format(self.cli_ctx.name)
-        self.assertIn(remove_space(expected), remove_space(actual))
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     def test_experimental_arguments_execute(self):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -15,7 +15,7 @@ import argparse
 from knack.arguments import ArgumentsContext
 from knack.commands import CLICommandsLoader, CommandGroup
 
-from tests.util import DummyCLI, redirect_io, disable_color
+from tests.util import DummyCLI, redirect_io, assert_in_multi_line, disable_color
 
 
 def example_handler(arg1, arg2=None, arg3=None):
@@ -75,7 +75,7 @@ Commands:
     cmd1 [Preview] : Short summary here.
 
 """.format(self.cli_ctx.name)
-        self.assertEqual(expected, actual)
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     def test_preview_command_plain_execute(self):
@@ -170,7 +170,7 @@ Commands:
     cmd1 : Short summary here.
 
 """.format(self.cli_ctx.name)
-        self.assertEqual(expected, actual)
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     @disable_color
@@ -202,7 +202,7 @@ Command
         Command group 'group1' is in preview. It may be changed/removed in a future
         release.
 """.format(self.cli_ctx.name)
-        self.assertIn(expected, actual)
+        assert_in_multi_line(expected, actual)
 
 
 class TestArgumentPreview(unittest.TestCase):
@@ -245,7 +245,7 @@ Arguments
     --arg1 [Preview] [Required] : Arg1.
         Argument '--arg1' is in preview. It may be changed/removed in a future release.
 """.format(self.cli_ctx.name)
-        self.assertIn(expected, actual)
+        assert_in_multi_line(expected, actual)
 
     @redirect_io
     @disable_color

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,11 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from collections import namedtuple
 import unittest
+from collections import namedtuple
 from datetime import date, time, datetime
+from unittest import mock
 
-from knack.util import todict, to_snake_case
+from knack.util import todict, to_snake_case, is_modern_terminal
 
 
 class TestUtils(unittest.TestCase):
@@ -86,6 +87,16 @@ class TestUtils(unittest.TestCase):
         expected = 'this_is_snake_cased'
         actual = to_snake_case(the_input)
         self.assertEqual(expected, actual)
+
+    def test_is_modern_terminal(self):
+        with mock.patch.dict("os.environ", clear=True):
+            self.assertEqual(is_modern_terminal(), False)
+        with mock.patch.dict("os.environ", TERM_PROGRAM='vscode'):
+            self.assertEqual(is_modern_terminal(), True)
+        with mock.patch.dict("os.environ", PYCHARM_HOSTED='1'):
+            self.assertEqual(is_modern_terminal(), True)
+        with mock.patch.dict("os.environ", WT_SESSION='c25cb945-246a-49e5-b37a-1e4b6671b916'):
+            self.assertEqual(is_modern_terminal(), True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Init colomara only on Windows, because

- Bash of Linux and MacOS already supports control sequences
- Removing the colomara wrapper increases the output performance
- `_should_init_colorama` can be furtherly disabled by Azure CLI