### PR TITLE
Change build SVG to Azure DevOps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ Knack
 .. image:: https://img.shields.io/pypi/pyversions/knack.svg
     :target: https://pypi.python.org/pypi/knack
 
-.. image:: https://travis-ci.org/Microsoft/knack.svg?branch=master
-    :target: https://travis-ci.org/Microsoft/knack
+.. image:: https://dev.azure.com/azure-sdk/public/_apis/build/status/cli/microsoft.knack?branchName=master
+    :target: https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=1643&branchName=master
 
 
 ------------
@@ -34,7 +34,7 @@ Installation is easy via pip:
 Knack can be installed as a non-privileged user to your home directory by adding "--user" as below:
 
 .. code-block:: bash
-    
+
     pip install knack --user
 
 ------------
@@ -148,4 +148,3 @@ License
 =======
 
 Knack is licensed under `MIT <LICENSE>`__.
-


### PR DESCRIPTION
As we have moved from Travis CI to Azure DevOps, change the build SVG accordingly to use Azure DevOps's [Status - Get](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/status/get?view=azure-devops-rest-6.0) API.

To get the URLs, open https://dev.azure.com/azure-sdk/public/_build?definitionId=1643&_a=summary and click

![image](https://user-images.githubusercontent.com/4003950/110735039-f644a880-8263-11eb-8735-4f2fc796aef1.png)

Output:

```
[![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/cli/microsoft.knack?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=1643&branchName=master)
```