### PR TITLE
Rename master branch to dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Knack
 .. image:: https://img.shields.io/pypi/pyversions/knack.svg
     :target: https://pypi.python.org/pypi/knack
 
-.. image:: https://travis-ci.org/Microsoft/knack.svg?branch=master
+.. image:: https://travis-ci.org/Microsoft/knack.svg?branch=dev
     :target: https://travis-ci.org/Microsoft/knack
 
 
@@ -34,7 +34,7 @@ Installation is easy via pip:
 Knack can be installed as a non-privileged user to your home directory by adding "--user" as below:
 
 .. code-block:: bash
-    
+
     pip install knack --user
 
 ------------
@@ -88,13 +88,13 @@ Usage
     # "abcdefghijklmnopqrstuvwxyz"
 
 
-More samples and snippets are available at `examples <https://github.com/Microsoft/knack/tree/master/examples>`__.
+More samples and snippets are available at `examples <https://github.com/Microsoft/knack/tree/dev/examples>`__.
 
 
 Documentation
 =============
 
-Documentation is available at `docs <https://github.com/Microsoft/knack/tree/master/docs>`__.
+Documentation is available at `docs <https://github.com/Microsoft/knack/tree/dev/docs>`__.
 
 Developer Setup
 ===============
@@ -148,4 +148,3 @@ License
 =======
 
 Knack is licensed under `MIT <LICENSE>`__.
-

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,16 +8,16 @@ number and Z is the patch release number. This project strictly follows
 
 Modify the version number in `setup.py` and create a pull request for the changes.
 
-### Release with Travis CI (preferred option)
+### Release with Azure DevOps (preferred option)
 
-Once the changes have been merged to master, create a tag on GitHub for that commit.
+Once the changes have been merged to `dev`, create a tag on GitHub for that commit.
 Follow the format of other releases in the release notes you create on GitHub.
 
-A Travis CI build will be kicked-off that will publish to PyPI.
+Visit [Knack Release](https://dev.azure.com/azure-sdk/internal/_release?definitionId=83) to publish to PyPI.
 
 ### Release manually (backup option)
 
-Once the changes have been merged to master, continue with the rest of the release.
+Once the changes have been merged to `dev`, continue with the rest of the release.
 
 ```
 git clone https://github.com/microsoft/knack


### PR DESCRIPTION
Rename `master` branch to `dev` as suggested by https://github.com/Azure/azure-sdk/issues/1447.

[Azure CLI](https://github.com/Azure/azure-cli) and [MSAL.PY](https://github.com/AzureAD/microsoft-authentication-library-for-python) use `dev` as the main branch, so do the same for knack.

Ref email: _On changing the name of the GitHub default branch_