### PR TITLE
Unpin PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ jmespath==0.9.5
 mock==4.0.1
 pylint==2.6.0
 Pygments==2.5.2
-PyYAML==5.3.1
+PyYAML==5.4.1
 six==1.14.0
 tabulate==0.8.6
 vcrpy==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ jmespath==0.9.5
 mock==4.0.1
 pylint==2.6.0
 Pygments==2.5.2
-PyYAML==5.4.1
+PyYAML
 six==1.14.0
 tabulate==0.8.6
 vcrpy==4.0.2


### PR DESCRIPTION
Unpin PyYAML so that the latest version will always be used. This solves

https://dev.azure.com/azure-sdk/public/_build/results?buildId=781110&view=logs&j=74095127-2a27-5370-37ed-15a4193f243f&t=a1e0e2fa-9206-5f67-cee4-df0dbeea0a5f&l=515

```
[INFO] __________________________________________________________________________________________________________________ 
[INFO] |Security Alerts                                                                                                 | 
[INFO] |________________________________________________________________________________________________________________| 
[INFO] |Alert title                             |Affected component                      |Severity                      | 
[INFO] |________________________________________|________________________________________|______________________________| 
[INFO] |CVE-2020-14343                          |pyyaml 5.3.1                            |Critical                      | 
[INFO] |________________________________________|________________________________________|______________________________| 
```
