### PR TITLE
Add error message for invalid argument value

### DIFF
--- a/examples/exapp2
+++ b/examples/exapp2
@@ -59,6 +59,16 @@ type: group
 short-summary: An experimental command group
 """
 
+helps['demo'] = """
+type: group
+short-summary: A command group for demos.
+"""
+
+helps['demo arg'] = """
+type: group
+short-summary: A command showing how to use arguments.
+"""
+
 
 def abc_show_command_handler():
     """
@@ -151,6 +161,13 @@ def hello_command_handler(greetings=None):
     return ['Hello World!', greetings]
 
 
+def demo_arg_handler(move=None):
+    if move:
+        print("Your move was: {}".format(move))
+        return
+    print("Nothing to do.")
+
+
 WELCOME_MESSAGE = r"""
    _____ _      _____ 
   / ____| |    |_   _|
@@ -179,6 +196,7 @@ class MyCommandsLoader(CLICommandsLoader):
             g.command('hello', 'hello_command_handler', confirmation=True)
             g.command('sample-json', 'sample_json_handler')
             g.command('sample-logger', 'sample_logger_handler')
+
         with CommandGroup(self, 'abc', '__main__#{}') as g:
             g.command('list', 'abc_list_command_handler')
             g.command('show', 'abc_show_command_handler')
@@ -202,12 +220,20 @@ class MyCommandsLoader(CLICommandsLoader):
         # A deprecated command group
         with CommandGroup(self, 'dep', '__main__#{}', deprecate_info=g.deprecate(redirect='ga', hide='1.0.0')) as g:
             g.command('range', 'range_command_handler')
+
+        with CommandGroup(self, 'demo', '__main__#{}') as g:
+            g.command('arg', 'demo_arg_handler')
+
         return super(MyCommandsLoader, self).load_command_table(args)
 
     def load_arguments(self, command):
         with ArgumentsContext(self, 'ga range') as ac:
             ac.argument('start', type=int, is_preview=True)
             ac.argument('end', type=int, is_experimental=True)
+
+        with ArgumentsContext(self, 'demo arg') as ac:
+            ac.argument('move', choices=['rock', 'paper', 'scissors'])
+
         super(MyCommandsLoader, self).load_arguments(command)
 
 

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -30,20 +30,6 @@ ARGPARSE_SUPPORTED_KWARGS = [
 ]
 
 
-def _get_action_name(argument):
-    # copied from argparse in order not to use a protected method
-    if argument is None:
-        return None
-    if argument.option_strings:
-        return '/'.join(argument.option_strings)
-    if argument.metavar not in (None, argparse.SUPPRESS):
-        return argument.metavar
-    if argument.dest not in (None, argparse.SUPPRESS):
-        return argument.dest
-
-    return None
-
-
 class CLICommandParser(argparse.ArgumentParser):
 
     @staticmethod
@@ -280,34 +266,24 @@ class CLICommandParser(argparse.ArgumentParser):
         import sys
 
         if action.choices is not None and value not in action.choices:
-            is_command = action.dest in ["_command", "_subcommand"]
-            candidates = action.choices
-            if is_command:
-                candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
-
-            if candidates:
-                print_args = {
-                    's': 's' if len(candidates) > 1 else '',
-                    'verb': 'are' if len(candidates) > 1 else 'is',
-                    'value': value,
-                    'action': _get_action_name(action),
-                    'choices': ', '.join(map(repr, candidates))
-                }
-
-            if is_command:
-                # parser has no `command_source`, value is part of command itself
+            if action.dest in ["_command", "_subcommand"]:
+                # Command
                 error_msg = "{prog}: '{value}' is not in the '{prog}' command group. See '{prog} --help'.".format(
                     prog=self.prog, value=value)
                 logger.error(error_msg)
+                # Show suggestions
+                candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
                 if candidates:
-                    suggestion_msg = "\nThe most similar choice{s} to '{value}' {verb}:\n".format(**print_args)
+                    suggestion_msg = "\nThe most similar choices to '{value}':\n".format(value=value)
                     suggestion_msg += '\n'.join(['\t' + candidate for candidate in candidates])
                     print(suggestion_msg, file=sys.stderr)
             else:
-                error_msg = "{prog}: invalid choice '{value}'. See '{prog} --help'.".format(
-                    prog=self.prog, value=value)
+                # Argument
+                error_msg = "{prog}: '{value}' is not a valid value for '{name}'.".format(
+                    prog=self.prog, value=value,
+                    name=argparse._get_action_name(action))  # pylint: disable=protected-access
                 logger.error(error_msg)
-                suggestion_msg = "\nPossible choice{s} for argument '{action}' {verb}:\n".format(**print_args)
-                suggestion_msg += '\n'.join(['\t' + candidate for candidate in candidates])
+                # Show all allowed values
+                suggestion_msg = "Allowed values: " + ', '.join(action.choices)
                 print(suggestion_msg, file=sys.stderr)
             self.exit(2)

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -265,6 +265,8 @@ class CLICommandParser(argparse.ArgumentParser):
         import difflib
         import sys
 
+        super(CLICommandParser, self)._check_value(action, value)
+
         if action.choices is not None and value not in action.choices:
             # parser has no `command_source`, value is part of command itself
             error_msg = "{prog}: '{value}' is not in the '{prog}' command group. See '{prog} --help'.".format(

--- a/knack/parser.py
+++ b/knack/parser.py
@@ -35,7 +35,7 @@ def _get_action_name(argument):
     if argument is None:
         return None
     if argument.option_strings:
-        return  '/'.join(argument.option_strings)
+        return '/'.join(argument.option_strings)
     if argument.metavar not in (None, argparse.SUPPRESS):
         return argument.metavar
     if argument.dest not in (None, argparse.SUPPRESS):


### PR DESCRIPTION
Fix #236
Migrated from https://github.com/microsoft/knack/pull/237

## Symptom

Knack can only give error message for invalid command, but not invalid argument value. 
History: https://github.com/microsoft/knack/pull/237#issuecomment-801876101

## Change

Add error message for invalid argument value.

## Testing guide
```
> python examples\exapp2 demo arg1
exapp2 demo: 'arg1' is not in the 'exapp2 demo' command group. See 'exapp2 demo --help'.

The most similar choices to 'arg1':
        arg

> python D:\cli\knack\examples\exapp2 demo arg --move rok
exapp2 demo arg: 'rok' is not a valid value for '--move'.
Allowed values: rock, paper, scissors
```

ℹ As `Allowed values: rock, paper, scissors` appears in one line, it is not needed to add an empty line before it.