### PR TITLE
Always use UTF-8 for log file encoding

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.8.2
++++++
+
+* Always use UTF-8 for log file encoding (#247)
+
 0.8.1
 +++++
 

--- a/knack/log.py
+++ b/knack/log.py
@@ -16,6 +16,8 @@ CLI_LOGGER_NAME = 'cli'
 # without --debug flag.
 cli_logger_names = [CLI_LOGGER_NAME]
 
+LOG_FILE_ENCODING = 'utf-8'
+
 
 class CliLogLevel(IntEnum):
     CRITICAL = 0
@@ -163,7 +165,8 @@ class CLILogging:  # pylint: disable=too-many-instance-attributes
         ensure_dir(self.log_dir)
         log_file_path = os.path.join(self.log_dir, self.logfile_name)
         from logging.handlers import RotatingFileHandler
-        logfile_handler = RotatingFileHandler(log_file_path, maxBytes=10 * 1024 * 1024, backupCount=5)
+        logfile_handler = RotatingFileHandler(log_file_path, maxBytes=10 * 1024 * 1024, backupCount=5,
+                                              encoding=LOG_FILE_ENCODING)
         lfmt = logging.Formatter('%(process)d : %(asctime)s : %(levelname)s : %(name)s : %(message)s')
         logfile_handler.setFormatter(lfmt)
         logfile_handler.setLevel(logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = '0.8.1'
+VERSION = '0.8.2'
 
 DEPENDENCIES = [
     'argcomplete',


### PR DESCRIPTION
## Context

Reported by https://github.com/Azure/azure-cli/issues/17994

On Windows with English as the system language (without UTC-8 enabled), the system encoding by default is `cp1252` (Western Europe), and Python will use `cp1252` as the file encoding by default. 

Writing Unicode characters like `汉字` to log file results in error:

```
Traceback (most recent call last):
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38\lib\logging\__init__.py", line 1084, in emit
    stream.write(msg + self.terminator)
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 87-88: character maps to <undefined>
```

The error can also be easily reproduced with 

```py
with open("test.txt", "w") as f:
    print(f.encoding)
    f.write("汉字")
```

```
cp1252
Traceback (most recent call last):
  File "D:/cli/testproj/test1.py", line 2, in <module>
    f.write("汉字")
  File "C:\Users\jiasli\AppData\Local\Programs\Python\Python38\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-1: character maps to <undefined>
```

## Change

This PR forces log files to use UTF-8 so that file logging works on non-UTF-8 systems as well.

## Alternative solution

One may also follow https://github.com/microsoft/knack/pull/178 to change the default encoding of the system to UTF-8.
