### PR TITLE
Always use unittest.mock rather than PyPI mock.

### DIFF
--- a/knack/testsdk/patches.py
+++ b/knack/testsdk/patches.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 from .exceptions import CliTestError
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ argcomplete==1.12.2
 colorama==0.4.4
 flake8==3.8.4
 jmespath==0.10.0
-mock==4.0.3
 Pygments==2.8.1
 pylint==2.7.2
 pytest==6.2.2

--- a/tests/test_cli_scenarios.py
+++ b/tests/test_cli_scenarios.py
@@ -6,11 +6,7 @@
 import os
 from collections import OrderedDict
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-import mock
+from unittest import mock
 
 from io import StringIO
 

--- a/tests/test_command_with_configured_defaults.py
+++ b/tests/test_command_with_configured_defaults.py
@@ -6,10 +6,7 @@ import os
 import logging
 import sys
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from knack.arguments import ArgumentsContext
 from knack.commands import CLICommandsLoader, CommandGroup

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -5,10 +5,7 @@
 
 import os
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from knack.completion import CLICompletion, CaseInsensitiveChoicesCompleter, ARGCOMPLETE_ENV_NAME
 from tests.util import MockContext

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,10 +7,7 @@ import os
 import stat
 import unittest
 import shutil
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 import configparser
 
 from knack.config import CLIConfig

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from knack.arguments import ArgumentsContext
 from knack.commands import CLICommandsLoader, CommandGroup

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 import sys
 import argparse

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -5,8 +5,8 @@
 
 import sys
 import unittest
+from unittest import mock
 
-import mock
 from knack.arguments import ArgumentsContext
 from knack.commands import CLICommandsLoader, CommandGroup
 from knack.events import EVENT_PARSER_GLOBAL_CREATE

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 import logging
 
 from knack.events import EVENT_PARSER_GLOBAL_CREATE, EVENT_INVOKER_PRE_CMD_TBL_CREATE

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -7,7 +7,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 from collections import OrderedDict
 from io import StringIO
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 import sys
 import argparse

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -5,10 +5,7 @@
 
 import sys
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 from io import StringIO
 
 from knack.prompting import (verify_is_a_tty, NoTTYException, _INVALID_PASSWORD_MSG, prompt,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from knack.events import EVENT_PARSER_GLOBAL_CREATE
 from knack.query import CLIQuery

--- a/tests/util.py
+++ b/tests/util.py
@@ -3,10 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 import logging
 import os
 import re


### PR DESCRIPTION
Since only Python 3.6+ is supported, there is no need to use the `mock`
backport package. This commit ensures that only the standard library’s
`unittest.mock` is needed.

Replaces a mixture of conditional and unconditional imports of `mock`
and/or `unittest.mock` with unconditional imports of `unittest.mock`,
and drops `mock` from `requirements.txt`.