### PR TITLE
Only install colorama on Windows

### DIFF
--- a/knack/cli.py
+++ b/knack/cli.py
@@ -98,7 +98,7 @@ class CLI(object):  # pylint: disable=too-many-instance-attributes
         self.only_show_errors = self.config.getboolean('core', 'only_show_errors', fallback=False)
         self.enable_color = self._should_enable_color()
         # Init colorama only in Windows legacy terminal
-        self._should_init_colorama = self.enable_color and os.name == 'nt' and not is_modern_terminal()
+        self._should_init_colorama = self.enable_color and sys.platform == 'win32' and not is_modern_terminal()
 
     @staticmethod
     def _should_show_version(args):

--- a/setup.py
+++ b/setup.py
@@ -5,21 +5,24 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from codecs import open
-from setuptools import setup, find_packages
+import sys
+from setuptools import setup
 
 VERSION = '0.8.2'
 
 DEPENDENCIES = [
     'argcomplete',
-    'colorama',
     'jmespath',
     'pygments',
     'pyyaml',
     'tabulate'
 ]
 
-with open('README.rst', 'r', encoding='utf-8') as f:
+# On Windows, colorama is required for legacy terminals.
+if sys.platform == 'win32':
+    DEPENDENCIES.append('colorama')
+
+with open('README.rst', 'r') as f:
     README = f.read()
 
 setup(


### PR DESCRIPTION
As colorama is only initialized on Windows (#238), it should not be installed on Linux or MacOS.
