### PR TITLE
Release 0.9.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 
-0.8.3
+0.9.0
 +++++
 
 * Support Python 3.10 (#250)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 import sys
 from setuptools import setup
 
-VERSION = '0.8.3'
+VERSION = '0.9.0'
 
 DEPENDENCIES = [
     'argcomplete',


### PR DESCRIPTION
Depending on `colorama` is **internal** to Knack, so **dropping `colorama` shouldn't be considered as a breaking change**.

However, `azure-cli-core` directly relies on `colorama` but didn't declare the dependency in `setup.py`:

https://github.com/Azure/azure-cli/blob/b2a268a87d75d5ec2d2746697e6b5cec73e6e03e/src/azure-cli-core/azure/cli/core/_help.py#L92

```py
    def _print_az_find_message(command, enable_color):
        from colorama import Style
```

In other words, if `azure-cli-core` directly relies on `colorama`, it **should** declare `colorama` dependency.

`azure-cli-core` depends on knack with:

https://github.com/Azure/azure-cli/blob/36f7c914182d5f859b8e0d4650abf94b83df612a/src/azure-cli-core/setup.py#L52

```
    'knack~=0.8.2',
```

So knack 0.8.3 will get installed, which breaks `azure-cli-core`: https://github.com/Azure/azure-cli/issues/20206

It is impractical to release a hotfix for Azure CLI, so we removed 0.8.3 from PyPI and will release this new 0.9.0.
