### PR TITLE
Use proper PEP 508 environment marker to install colorama on Windows only

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.9.1
++++++
+
+* Use proper PEP 508 environment marker to install colorama on Windows only (#257)
+
 0.9.0
 +++++
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 import sys
 from setuptools import setup
 
-VERSION = '0.9.0'
+VERSION = '0.9.1'
 
 DEPENDENCIES = [
     'argcomplete',

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,10 @@ DEPENDENCIES = [
     'jmespath',
     'pygments',
     'pyyaml',
-    'tabulate'
+    'tabulate',
+    # On Windows, colorama is required for legacy terminals.
+    'colorama; sys_platform == "win32"'
 ]
-
-# On Windows, colorama is required for legacy terminals.
-if sys.platform == 'win32':
-    DEPENDENCIES.append('colorama')
 
 with open('README.rst', 'r') as f:
     README = f.read()


### PR DESCRIPTION
Issue #256

Using proper PEP 508 environment marker to install colorama on Windows only.
