### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ arch:
 sudo: false
 language: python
 python:
-- '3.6'
 - '3.7'
 - '3.8'
 - '3.9'

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -20,9 +20,6 @@ jobs:
       vmImage: 'ubuntu-20.04'
     strategy:
       matrix:
-        Python36:
-          python.version: '3.6'
-          tox_env: 'py36'
         Python37:
           python.version: '3.7'
           tox_env: 'py37'

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Intended Audience :: System Administrators',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Python 3.6 is reaching its end of support on 2021-12-23: https://www.python.org/downloads/
