### PR TITLE
Fix typos

### DIFF
--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -409,7 +409,7 @@ Arguments
 
     @redirect_io
     def test_deprecate_options_execute_hidden_non_deprecated(self):
-        """ Ensure hidden non-deprecated optionss can be used without warning. """
+        """ Ensure hidden non-deprecated options can be used without warning. """
         self.cli_ctx.invoke('arg-test --arg1 foo --opt1 bar --opt3 bar'.split())
         actual = self.io.getvalue()
         expected = "Option '--alt3' has been deprecated and will be removed in a future release. Use '--opt3' instead."

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -203,7 +203,7 @@ class TestHelp(unittest.TestCase):
 
     @redirect_io
     def test_help_long_and_short_description_from_docstring(self):
-        """ Ensure the first sentence of a docstring is parsed as the short summary and subsequent text is interpretted
+        """ Ensure the first sentence of a docstring is parsed as the short summary and subsequent text is interpreted
         as the long summary. """
 
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
Found via `codespell -L ans,falsy`.