### PR TITLE
{CI} Migrate knack pipeline to new organization azclitools

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     timeoutInMinutes: 20
 
     pool:
-      vmImage: 'ubuntu-20.04'
+      name: 'pool-ubuntu-2004'
     strategy:
       matrix:
         Python37:
@@ -50,7 +50,7 @@ jobs:
   - job: BuildPythonWheel
     condition: succeeded()
     pool:
-      vmImage: 'ubuntu-20.04'
+      name: 'pool-ubuntu-2004'
     steps:
       - task: UsePythonVersion@0
         displayName: Use Python 3.10


### PR DESCRIPTION
Migrate microsoft/knack pipeline to azclitools org.

[microsoft.knack(migration)](https://dev.azure.com/azclitools/public/_build?definitionId=64&_a=summary)
[Knack Release](https://dev.azure.com/azclitools/release/_release?_a=releases&view=all&definitionId=8)
