### PR TITLE
Add support for serialization of type bytearray

### DIFF
--- a/knack/output.py
+++ b/knack/output.py
@@ -25,7 +25,7 @@ def _decode_str(output):
 class _ComplexEncoder(json.JSONEncoder):
 
     def default(self, o):  # pylint: disable=method-hidden
-        if isinstance(o, bytes) or isinstance(o, bytearray):
+        if isinstance(o, (bytes, bytearray)):
             return o.decode()
         return json.JSONEncoder.default(self, o)
 

--- a/knack/output.py
+++ b/knack/output.py
@@ -25,7 +25,7 @@ def _decode_str(output):
 class _ComplexEncoder(json.JSONEncoder):
 
     def default(self, o):  # pylint: disable=method-hidden
-        if isinstance(o, bytes) and not isinstance(o, str):
+        if (isinstance(o, bytes) or isinstance(o, bytearray)) and not isinstance(o, str):
             return o.decode()
         return json.JSONEncoder.default(self, o)
 

--- a/knack/output.py
+++ b/knack/output.py
@@ -25,7 +25,7 @@ def _decode_str(output):
 class _ComplexEncoder(json.JSONEncoder):
 
     def default(self, o):  # pylint: disable=method-hidden
-        if (isinstance(o, bytes) or isinstance(o, bytearray)) and not isinstance(o, str):
+        if isinstance(o, bytes) or isinstance(o, bytearray):
             return o.decode()
         return json.JSONEncoder.default(self, o)
 


### PR DESCRIPTION
For all preview API versions since 2022-09-02-preview, a new property named [ManagedClusterSecurityProfileCustomCATrustCertificates](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-09-02-preview/managedClusters.json#L6605) is added in containerservice(AKS). The property is declared with type `array`, where the value of each item is of type `string` and **format `byte`**. Thus, the [generated SDK](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/containerservice/azure-mgmt-containerservice/azure/mgmt/containerservice/v2022_09_02_preview/models/_models_py3.py#L5718) declares the property as type `[btyearray]`. It could be seen that the [serialization helpers](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/containerservice/azure-mgmt-containerservice/azure/mgmt/containerservice/_serialization.py#L1033) that comes with the SDK could handle properties of type `bytearray`. But the serialization processing in knack is not competent, so opened this PR to add support for serialization of type `bytearray`.