### PR TITLE
fix default value set for bool type

### DIFF
--- a/knack/commands.py
+++ b/knack/commands.py
@@ -124,8 +124,8 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         # that coincides with the default
         if isinstance(arg_default, str):
             arg_default = DefaultStr(arg_default)
-        elif type(arg_default) is int:  # pylint: disable=unidiomatic-typecheck
-            # use type here is because:
+        elif isinstance(arg_default, int) and not isinstance(arg_default, bool):
+            # adjust here is because:
             # 1) bool is subclass of int so isinstance(True, int) cannot distinguish between int and bool
             # 2) bool is not extendable according to
             #   https://stackoverflow.com/questions/2172189/why-i-cant-extend-bool-in-python,

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -17,7 +17,7 @@ from .introspection import extract_args_from_signature, extract_full_summary_fro
 from .events import (EVENT_CMDLOADER_LOAD_COMMAND_TABLE, EVENT_CMDLOADER_LOAD_ARGUMENTS,
                      EVENT_COMMAND_CANCELLED)
 from .log import get_logger
-from .validators import DefaultInt, DefaultStr
+from .validators import DefaultInt, DefaultStr, DefaultBool
 
 logger = get_logger(__name__)
 
@@ -125,7 +125,7 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         if isinstance(arg_default, str):
             arg_default = DefaultStr(arg_default)
         elif isinstance(arg_default, bool):
-            pass
+            arg_default = DefaultBool(arg_default)
         elif isinstance(arg_default, int):
             arg_default = DefaultInt(arg_default)
         # update the default

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -129,7 +129,7 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         elif isinstance(arg_default, int):
             arg_default = DefaultInt(arg_default)
         # update the default
-        if arg_default:
+        if arg_default is not None:
             arg.type.settings['default'] = arg_default
 
     def execute(self, **kwargs):

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -124,6 +124,8 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         # that coincides with the default
         if isinstance(arg_default, str):
             arg_default = DefaultStr(arg_default)
+        elif isinstance(arg_default, bool):
+            pass
         elif isinstance(arg_default, int):
             arg_default = DefaultInt(arg_default)
         # update the default

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -17,7 +17,7 @@ from .introspection import extract_args_from_signature, extract_full_summary_fro
 from .events import (EVENT_CMDLOADER_LOAD_COMMAND_TABLE, EVENT_CMDLOADER_LOAD_ARGUMENTS,
                      EVENT_COMMAND_CANCELLED)
 from .log import get_logger
-from .validators import DefaultInt, DefaultStr, DefaultBool
+from .validators import DefaultInt, DefaultStr
 
 logger = get_logger(__name__)
 
@@ -124,12 +124,15 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         # that coincides with the default
         if isinstance(arg_default, str):
             arg_default = DefaultStr(arg_default)
-        elif isinstance(arg_default, bool):
-            arg_default = DefaultBool(arg_default)
-        elif isinstance(arg_default, int):
+        elif type(arg_default) is int:
+            # use type here is because:
+            # 1) bool is subclass of int so isinstance(True, int) cannot distinguish between int and bool
+            # 2) bool is not extendable according to
+            #   https://stackoverflow.com/questions/2172189/why-i-cant-extend-bool-in-python,
+            #   so bool's is_default is ignored for now
             arg_default = DefaultInt(arg_default)
         # update the default
-        if arg_default is not None:
+        if arg_default:
             arg.type.settings['default'] = arg_default
 
     def execute(self, **kwargs):

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -127,9 +127,8 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         elif isinstance(arg_default, int) and not isinstance(arg_default, bool):
             # adjust here is because:
             # 1) bool is subclass of int so isinstance(True, int) cannot distinguish between int and bool
-            # 2) bool is not extendable according to
-            #   https://stackoverflow.com/questions/2172189/why-i-cant-extend-bool-in-python,
-            #   so bool's is_default is ignored for now
+            # 2) bool is not extendable according to https://stackoverflow.com/a/2172204/6140424,
+            #    so bool's is_default is ignored for now
             arg_default = DefaultInt(arg_default)
         # update the default
         if arg_default:

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -124,7 +124,7 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         # that coincides with the default
         if isinstance(arg_default, str):
             arg_default = DefaultStr(arg_default)
-        elif type(arg_default) is int:
+        elif type(arg_default) is int:  # pylint: disable=unidiomatic-typecheck
             # use type here is because:
             # 1) bool is subclass of int so isinstance(True, int) cannot distinguish between int and bool
             # 2) bool is not extendable according to

--- a/knack/commands.py
+++ b/knack/commands.py
@@ -125,10 +125,9 @@ class CLICommand(object):  # pylint:disable=too-many-instance-attributes
         if isinstance(arg_default, str):
             arg_default = DefaultStr(arg_default)
         elif isinstance(arg_default, int) and not isinstance(arg_default, bool):
-            # adjust here is because:
-            # 1) bool is subclass of int so isinstance(True, int) cannot distinguish between int and bool
-            # 2) bool is not extendable according to https://stackoverflow.com/a/2172204/6140424,
-            #    so bool's is_default is ignored for now
+            # bool's is_default is ignored for now, because
+            # 1. bool is a subclass of int, so isinstance(True, int) cannot distinguish between int and bool
+            # 2. bool is not extendable according to https://stackoverflow.com/a/2172204/2199657
             arg_default = DefaultInt(arg_default)
         # update the default
         if arg_default:

--- a/knack/validators.py
+++ b/knack/validators.py
@@ -18,14 +18,3 @@ class DefaultInt(int):
         instance = int.__new__(cls, *args, **kwargs)
         instance.is_default = True
         return instance
-
-
-class DefaultBool:
-
-    def __new__(cls, default_value):
-        instance = bool(default_value)
-        return instance
-
-    def __getattr__(self, key, value):
-        if key == "is_default":
-            return True

--- a/knack/validators.py
+++ b/knack/validators.py
@@ -18,3 +18,14 @@ class DefaultInt(int):
         instance = int.__new__(cls, *args, **kwargs)
         instance.is_default = True
         return instance
+
+
+class DefaultBool:
+
+    def __new__(cls, default_value):
+        instance = bool(default_value)
+        return instance
+
+    def __getattr__(self, key, value):
+        if key == "is_default":
+            return True


### PR DESCRIPTION
`bool` is subclass of int, while default `True` or `False` should not be converted into int `1` or `0`.
Otherwise, type check would fail for `aaz` cmds (https://github.com/Azure/azure-cli/blob/58ac6ab07fa850e1a6458dec87af91cd6725069e/src/azure-cli-core/azure/cli/core/aaz/_field_type.py#L47)