### PR TITLE
Release 0.11.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+0.11.0
+++++++
+
+* Declare support for Python 3.11 and drop support for Python 3.7 (#275)
+* Stop converting argument's `bool` default value to `DefaultInt` (#273)
+
 0.10.1
 ++++++
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 import sys
 from setuptools import setup
 
-VERSION = '0.10.1'
+VERSION = '0.11.0'
 
 DEPENDENCIES = [
     'argcomplete',


### PR DESCRIPTION
* Declare support for Python 3.11 and drop support for Python 3.7 (#275)
* Stop converting argument's `bool` default value to `DefaultInt` (#273)