### PR TITLE
Use try-finally to ensure `filter_output` is unregistered

### DIFF
--- a/knack/query.py
+++ b/knack/query.py
@@ -42,9 +42,11 @@ class CLIQuery(object):
         if query_expression:
             def filter_output(cli_ctx, **kwargs):
                 from jmespath import Options
-                kwargs['event_data']['result'] = query_expression.search(
-                    kwargs['event_data']['result'], Options(collections.OrderedDict))
-                cli_ctx.unregister_event(EVENT_INVOKER_FILTER_RESULT, filter_output)
+                try:
+                    kwargs['event_data']['result'] = query_expression.search(
+                        kwargs['event_data']['result'], Options(collections.OrderedDict))
+                finally:
+                    cli_ctx.unregister_event(EVENT_INVOKER_FILTER_RESULT, filter_output)
             cli_ctx.register_event(EVENT_INVOKER_FILTER_RESULT, filter_output)
             cli_ctx.invocation.data['query_active'] = True
 


### PR DESCRIPTION
**Related Issue**
https://github.com/Azure/azure-cli/issues/27228

**Description**
If `query_expression.search` raises an Exception, the following line `cli_ctx.unregister_event(EVENT_INVOKER_FILTER_RESULT, filter_output)` won't be executed, and the callback with error remains in the `_event_handlers`. 
![image](https://github.com/microsoft/knack/assets/32201005/c7cee312-eff5-4727-94ba-86ae14cbd1b6)
Az Interactive uses the same `cli_ctx` for every command execution, so if there is an exception related to `--query`, it will keep happening for any subsequent commands.
![image](https://github.com/microsoft/knack/assets/32201005/2d27949e-f3a6-4031-a24a-b1c5c01cc6c2)
