### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -20,9 +20,6 @@ jobs:
       name: 'pool-ubuntu-2004'
     strategy:
       matrix:
-        Python38:
-          python.version: '3.8'
-          tox_env: 'py38'
         Python39:
           python.version: '3.9'
           tox_env: 'py39'

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'Intended Audience :: System Administrators',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -253,7 +253,7 @@ class TestCLIConfig(unittest.TestCase):
         file_mode = os.stat(self.cli_config.config_path).st_mode
         self.assertTrue(bool(file_mode & stat.S_IRUSR))
         self.assertTrue(bool(file_mode & stat.S_IWUSR))
-        # only S_IRUSR and S_IWUSR are supported on Windows: https://docs.python.org/3.8/library/os.html#os.chmod
+        # only S_IRUSR and S_IWUSR are supported on Windows: https://docs.python.org/3.12/library/os.html#os.chmod
         if os.name != 'nt':
             self.assertFalse(bool(file_mode & stat.S_IXUSR))
             self.assertFalse(bool(file_mode & stat.S_IRGRP))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py39,py310,py311,py312
 [testenv]
 deps = -rrequirements.txt
 commands=


### PR DESCRIPTION
Python 3.8 is EOL and we should drop support for it.