### PR TITLE
Use `pool-ubuntu-latest-multi-core` pool

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     timeoutInMinutes: 20
 
     pool:
-      name: 'pool-ubuntu-2004'
+      name: 'pool-ubuntu-latest-multi-core'
     strategy:
       matrix:
         Python38:
@@ -53,7 +53,7 @@ jobs:
   - job: BuildPythonWheel
     condition: succeeded()
     pool:
-      name: 'pool-ubuntu-2004'
+      name: 'pool-ubuntu-latest-multi-core'
     steps:
       - task: UsePythonVersion@0
         inputs:


### PR DESCRIPTION
According to https://github.com/actions/runner-images, Ubuntu 20.04 has been deprecated, so use `pool-ubuntu-latest-multi-core` pool.