### PR TITLE
Release 0.14.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.14.0
+++++++
+
+* Declare support for Python 3.14 and drop support for Python 3.9 (#296)
+
 0.13.0
 ++++++
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 import sys
 from setuptools import setup
 
-VERSION = '0.13.0'
+VERSION = '0.14.0'
 
 DEPENDENCIES = [
     'argcomplete',


### PR DESCRIPTION
* Declare support for Python 3.14 and drop support for Python 3.9 (#296)