### PR TITLE
fix(parser): escape unescaped '%' in help text for Python 3.14 argpar…

### DIFF
--- a/knack/parser.py
+++ b/knack/parser.py
@@ -43,6 +43,18 @@ class CLICommandParser(argparse.ArgumentParser):
     def _add_argument(obj, arg):
         """ Only pass valid argparse kwargs to argparse.ArgumentParser.add_argument """
         argparse_options = {name: value for name, value in arg.options.items() if name in ARGPARSE_SUPPORTED_KWARGS}
+
+        # Python 3.14+ validates help strings at add_argument() time by running
+        # `help_string % params` (see https://github.com/python/cpython/pull/124899).
+        # Any bare '%' in help text causes ValueError/TypeError/KeyError since '%' is
+        # the Python old-style string formatting operator. CLI authors are not expected
+        # to escape '%' in help strings (no such requirement exists in docs), so we
+        # transparently escape '%' to '%%' before argparse validation and restore it
+        # afterward so users see the original unescaped text in help output.
+        help_string = argparse_options.get('help')
+        if help_string and '%' in help_string:
+            argparse_options['help'] = help_string.replace('%', '%%')
+
         if arg.options_list:
             scrubbed_options_list = []
             for item in arg.options_list:
@@ -61,13 +73,22 @@ class CLICommandParser(argparse.ArgumentParser):
                     setattr(option, 'deprecate_info', item)
                     item = option
                 scrubbed_options_list.append(item)
-            return obj.add_argument(*scrubbed_options_list, **argparse_options)
+            param = obj.add_argument(*scrubbed_options_list, **argparse_options)
+        else:
+            if 'required' in argparse_options:
+                del argparse_options['required']
+            if 'metavar' not in argparse_options:
+                argparse_options['metavar'] = '<{}>'.format(argparse_options['dest'].upper())
+            param = obj.add_argument(**argparse_options)
 
-        if 'required' in argparse_options:
-            del argparse_options['required']
-        if 'metavar' not in argparse_options:
-            argparse_options['metavar'] = '<{}>'.format(argparse_options['dest'].upper())
-        return obj.add_argument(**argparse_options)
+        # Restore the original unescaped help text so the CLI help renderer displays
+        # the correct single '%' characters to the user. Knack's help renderer reads
+        # action.help directly (not via argparse's _expand_help), so without this
+        # restore users would see '%%' literally in help output.
+        if help_string and '%' in help_string:
+            param.help = help_string
+
+        return param
 
     @staticmethod
     def _expand_prefixed_files(args):


### PR DESCRIPTION
This pull request updates the argument parsing logic in `knack/parser.py` to ensure that help strings containing `%` characters are handled correctly in Python 3.14 and above. The main change is to escape `%` characters in help texts before passing them to `argparse`, then restore the original help text so that CLI users see the intended output.

**Compatibility and Help String Handling:**

* Escapes `%` characters in help strings before passing them to `argparse` to avoid errors in Python 3.14+, and restores the original help text after argument creation so users see the correct help output. [[1]](diffhunk://#diff-1935a8df1a034f90b5a437b6ca22f3aced872bc2f444473d118b6ccc4e36c4faR46-R57) [[2]](diffhunk://#diff-1935a8df1a034f90b5a437b6ca22f3aced872bc2f444473d118b6ccc4e36c4faL64-R91)
### Background
Knack currently allows command help texts to contain unescaped `%` (for example `"%Y%m"`).Normally, this is fine because Knack prints help text directly and does **not** call argparse’s internal help rendering functions (such as `_expand_help` or `print_help`).  However, starting from **Python 3.14**, `argparse.ArgumentParser.add_argument()` validates help text by attempting to format it. If the help text contains an unescaped `%`, this validation step raises an exception.
### Problem
Simply escaping `%` in users' help text would change the rendered help output (for example `"%Y%m"` becoming `"%%Y%%m"`), which breaks existing behavior expected by Knack users.
### Proposed Fix
Before calling `argparse.add_argument()`, temporarily escape `%` characters in the help text to satisfy argparse’s validation.  After the argument is registered, restore the original help text.### Result- Keeps Knack’s existing rule that users can write `%` directly in help text- Avoids runtime exceptions introduced by Python 3.14’s stricter argparse validation- Preserves the help output exactly as written by command authors
