### PR TITLE
Fix/output encoding fallback replace

### DIFF
--- a/knack/output.py
+++ b/knack/output.py
@@ -152,9 +152,13 @@ class OutputProducer(object):
             else:
                 raise
         except UnicodeEncodeError:
-            logger.warning("Unable to encode the output with %s encoding. Unsupported characters are discarded.",
-                           out_file.encoding)
-            print(output.encode('ascii', 'ignore').decode('utf-8', 'ignore'),
+            # Retry with the stream's own encoding so that characters it *can* represent survive.
+            # Encoding to 'ascii' here would discard every non-ASCII character in the document,
+            # not just the ones the destination cannot represent.
+            encoding = out_file.encoding or 'ascii'
+            logger.warning("Unable to encode some characters with %s encoding. "
+                           "They are replaced with '?'.", encoding)
+            print(output.encode(encoding, 'replace').decode(encoding),
                   file=out_file, end='')
 
     def get_formatter(self, format_type):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -6,10 +6,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import json
 import unittest
 from unittest import mock
 from collections import OrderedDict
-from io import StringIO
+from io import BytesIO, StringIO, TextIOWrapper
 
 from knack.output import OutputProducer, format_json, format_json_color, format_yaml, format_yaml_color, \
     format_table, format_tsv
@@ -92,6 +93,41 @@ class TestOutput(unittest.TestCase):
   "contents": "生活很糟糕"
 }
 """))
+
+    def test_out_json_non_ASCII_unencodable(self):
+        """
+        When the destination stream cannot represent every character, only the characters that its
+        encoding genuinely cannot represent should be affected. Characters the encoding does support
+        must survive, and the unrepresentable ones should degrade to something visible.
+        """
+        output_producer = OutputProducer(cli_ctx=self.mock_ctx)
+        # cp1252 represents æ, ø, å and the em dash, but not U+221E INFINITY.
+        out_file = TextIOWrapper(BytesIO(), encoding='cp1252')
+        output_producer.out(CommandResultItem({'contents': 'æ ø å — ∞'}),
+                            formatter=format_json, out_file=out_file)
+        out_file.flush()
+        written = out_file.buffer.getvalue().decode('cp1252')
+
+        self.assertEqual(normalize_newlines(written), normalize_newlines(
+            """{
+  "contents": "æ ø å — ?"
+}
+"""))
+
+    def test_out_json_non_ASCII_unencodable_stays_parseable(self):
+        """
+        The fallback must not turn valid JSON into something a parser rejects, including for
+        characters outside the Basic Multilingual Plane such as emoji.
+        """
+        output_producer = OutputProducer(cli_ctx=self.mock_ctx)
+        out_file = TextIOWrapper(BytesIO(), encoding='cp1252')
+        output_producer.out(CommandResultItem({'contents': 'æ ø å 😀'}),
+                            formatter=format_json, out_file=out_file)
+        out_file.flush()
+        written = out_file.buffer.getvalue().decode('cp1252')
+
+        # The characters cp1252 supports survive, and the document still parses.
+        self.assertEqual(json.loads(written)['contents'], 'æ ø å ?')
 
     # YAML output tests
 


### PR DESCRIPTION
Fixes #303.

When the destination stream cannot encode the output, `OutputProducer.out` retried by encoding the whole document as ASCII with `errors='ignore'`. Because the retry targeted ASCII rather than the stream's own encoding, a single unrepresentable character anywhere in the output discarded *every* non-ASCII character in the document. On a Windows console in a non-UTF-8 locale, one emoji or CJK character stripped every accented Latin character from the rest of the result set, quietly replacing correct data with plausible-looking wrong data.

The retry now encodes with `out_file.encoding`, so only characters the destination genuinely cannot represent are affected. Those become `?` via `errors='replace'`, which keeps the document parseable in every output format. `backslashreplace` would preserve more information, but it emits `\U0001f600` for characters outside the Basic Multilingual Plane and JSON permits only `\uXXXX`, so emoji-containing output would stop parsing altogether; the issue sets out that trade-off, and switching the handler is a one-word change if you prefer it.

This also corrects the warning text, which named an encoding the fallback did not actually use and said "Unsupported characters are discarded" when supported ones were discarded too, and drops the `.decode('utf-8', 'ignore')` round trip, which was a no-op on bytes just produced by `.encode('ascii', 'ignore')`.

Nothing changes for streams that can encode the output: the fallback only runs when a `UnicodeEncodeError` is raised, so UTF-8 consoles are unaffected.

**Tests**

Two regression tests in `tests/test_output.py`, both failing before this change:

* `test_out_json_non_ASCII_unencodable` writes `æ ø å — ∞` to a cp1252 stream and asserts the four characters cp1252 supports survive, rather than being discarded along with U+221E.
* `test_out_json_non_ASCII_unencodable_stays_parseable` writes an emoji payload and asserts the output still parses as JSON, guarding the property that motivated `replace` over `backslashreplace`.

---

*Disclosure: the investigation behind this change and this description were produced with Claude Code. The full suite (247 tests), flake8 and pylint were run against `dev` at `52f769a`.*
