### PR TITLE
Fix default scalar values in command output

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+Unreleased
+++++++++++
+
+* Preserve default integer and string values in command output (#215)
+
 0.14.0
 ++++++
 

--- a/knack/util.py
+++ b/knack/util.py
@@ -9,6 +9,8 @@ import re
 from datetime import date, time, datetime, timedelta
 from enum import Enum
 
+from .validators import DefaultInt, DefaultStr
+
 NO_COLOR_VARIABLE_NAME = 'KNACK_NO_COLOR'
 
 # Override these values to customize the status message.
@@ -135,6 +137,10 @@ def todict(obj, post_processor=None):  # pylint: disable=too-many-return-stateme
     Convert an object to a dictionary. Use 'post_processor(original_obj, dictionary)' to update the
     dictionary in the process
     """
+    if isinstance(obj, DefaultInt):
+        return int(obj)
+    if isinstance(obj, DefaultStr):
+        return str(obj)
     if isinstance(obj, dict):
         result = {k: todict(v, post_processor) for (k, v) in obj.items()}
         return post_processor(obj, result) if post_processor else result

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,6 +9,7 @@ from datetime import date, time, datetime
 from unittest import mock
 
 from knack.util import todict, to_snake_case, is_modern_terminal
+from knack.validators import DefaultInt, DefaultStr
 
 
 class TestUtils(unittest.TestCase):
@@ -18,6 +19,15 @@ class TestUtils(unittest.TestCase):
         actual = todict(the_input)
         expected = None
         self.assertEqual(actual, expected)
+
+    def test_application_todict_default_scalars(self):
+        for value, expected in [(DefaultInt(100), 100), (DefaultStr('hello'), 'hello')]:
+            with self.subTest(value=value):
+                actual = todict(value)
+                self.assertEqual(actual, expected)
+                self.assertIs(type(actual), type(expected))
+                self.assertEqual(todict({'value': [value]}), {'value': [expected]})
+                self.assertTrue(value.is_default)
 
     def test_application_todict_dict_empty(self):
         the_input = {}


### PR DESCRIPTION
Default integer and string command arguments currently become `{"isDefault": true}` in output. `todict` reads the marker classes' `__dict__`, losing the value the command returned.

Convert `DefaultInt` and `DefaultStr` to their built-in scalar types before object conversion. Regression coverage checks direct and nested results, built-in output types, and retention of the original default marker.

Fixes #215.

Validation on macOS, Python 3.12.13:
- The new regression fails for both default types before the fix.
- `pytest`: 246 passed, 2 subtests passed.
- License verification, flake8, and all 3 example tests pass.
- Pylint reports E1120 in unchanged `knack/_win_vt.py:40`; it also reproduces when linting that unchanged module alone.

AI assistance: Codex assisted with investigation, implementation, and local verification.
